### PR TITLE
Fix auth, sync, shared folder support, and folder picker

### DIFF
--- a/src/api/chunkUpload.ts
+++ b/src/api/chunkUpload.ts
@@ -56,9 +56,8 @@ export class ChunkUploader {
 		logger.debug('Using simple upload for small file');
 
 		try {
-			const encodedPath = encodeURIComponent(filePath);
 			const graphClient = this.client.getClient();
-			const apiPath = this.client.getDriveEndpoint(`${encodedPath}:/content`);
+			const apiPath = this.client.buildEndpoint(filePath, 'content');
 
 			const response = await retryWithBackoff(() =>
 				graphClient.api(apiPath).putStream(content)
@@ -123,9 +122,8 @@ export class ChunkUploader {
 		logger.debug('Creating upload session for:', filePath);
 
 		try {
-			const encodedPath = encodeURIComponent(filePath);
 			const graphClient = this.client.getClient();
-			const apiPath = this.client.getDriveEndpoint(`${encodedPath}:/createUploadSession`);
+			const apiPath = this.client.buildEndpoint(filePath, 'createUploadSession');
 
 			const response = await retryWithBackoff(() =>
 				graphClient.api(apiPath).post({

--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -178,22 +178,39 @@ export class OneDriveClient {
 	}
 
 	/**
-	 * List folders at a specific path on the user's own drive.
-	 * Always uses /me/drive — ignores shared-folder configuration.
-	 * Used by the folder picker to browse the user's OneDrive.
+	 * List folders at a specific path for the folder picker.
+	 * For the user's own drive, uses /me/drive paths.
+	 * For shared folders, uses /drives/{driveId}/items/{itemId} paths.
 	 */
-	async listFoldersForPicker(folderPath: string = ''): Promise<OneDriveItem[]> {
-		logger.debug('Listing folders for picker:', folderPath);
+	async listFoldersForPicker(
+		folderPath: string = '',
+		sharedDriveId?: string,
+		sharedItemId?: string,
+		relativePathInShared?: string
+	): Promise<OneDriveItem[]> {
+		logger.debug('Listing folders for picker:', { folderPath, sharedDriveId, relativePathInShared });
 
 		try {
 			let apiPath: string;
-			const cleanPath = folderPath.replace(/^\/+|\/+$/g, '');
 
-			if (!cleanPath) {
-				apiPath = '/me/drive/root/children';
+			if (sharedDriveId && sharedItemId) {
+				// Inside a shared folder — use the remote drive
+				const cleanRelative = (relativePathInShared || '').replace(/^\/+|\/+$/g, '');
+				if (!cleanRelative) {
+					apiPath = `/drives/${sharedDriveId}/items/${sharedItemId}/children`;
+				} else {
+					const encoded = encodePathForGraph(cleanRelative);
+					apiPath = `/drives/${sharedDriveId}/items/${sharedItemId}:/${encoded}:/children`;
+				}
 			} else {
-				const encoded = encodePathForGraph(cleanPath);
-				apiPath = `/me/drive/root:/${encoded}:/children`;
+				// User's own drive
+				const cleanPath = folderPath.replace(/^\/+|\/+$/g, '');
+				if (!cleanPath) {
+					apiPath = '/me/drive/root/children';
+				} else {
+					const encoded = encodePathForGraph(cleanPath);
+					apiPath = `/me/drive/root:/${encoded}:/children`;
+				}
 			}
 
 			const response = await retryWithBackoff(() => this.client.api(apiPath).get());

--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -104,6 +104,35 @@ export class OneDriveClient {
 	}
 
 	/**
+	 * Resolve the actual path of a shared folder on its home drive.
+	 * Call after selecting a shared folder to get its full path for delta path stripping.
+	 */
+	async resolveSharedFolderPath(driveId: string, itemId: string): Promise<string> {
+		logger.debug('Resolving shared folder path:', { driveId, itemId });
+
+		try {
+			const response = await retryWithBackoff(() =>
+				this.client.api(`/drives/${driveId}/items/${itemId}`).get()
+			);
+
+			const item = response as OneDriveItem;
+			// Build the full path from parentReference.path + name
+			// parentReference.path is like "/drive/root:" or "/drive/root:/Documents/ObsidianVaults"
+			let parentPath = item.parentReference?.path || '';
+			parentPath = parentPath.replace(/^\/drive\/root:/, '');
+
+			const fullPath = parentPath ? `${parentPath}/${item.name}` : `/${item.name}`;
+			logger.info(`Resolved shared folder path: ${fullPath}`);
+			return fullPath;
+		} catch (error) {
+			logger.error('Failed to resolve shared folder path:', error);
+			throw new OneDriveError(
+				`Failed to resolve shared folder: ${error instanceof Error ? error.message : 'Unknown error'}`
+			);
+		}
+	}
+
+	/**
 	 * @deprecated Use buildEndpoint() instead. Kept for backward compat during migration.
 	 */
 	getDriveEndpoint(path: string): string {

--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -7,6 +7,7 @@ import { OneDriveAuthProvider } from '../auth/authProvider';
 import { OneDriveItem, OneDriveUser, OneDriveError, OneDriveAccessMode, DeltaResponse } from '../types';
 import { logger } from '../utils/logger';
 import { retryWithBackoff } from '../utils/retry';
+import { encodePathForGraph } from '../utils/pathUtils';
 
 /**
  * OneDrive client for interacting with Microsoft Graph API
@@ -15,6 +16,11 @@ export class OneDriveClient {
 	private client: Client;
 	private authProvider: OneDriveAuthProvider;
 	private accessMode: OneDriveAccessMode;
+
+	// Shared/mounted folder support
+	private remoteDriveId?: string;
+	private remoteItemId?: string;
+	private remoteRootName?: string;
 
 	constructor(authProvider: OneDriveAuthProvider, accessMode: OneDriveAccessMode = OneDriveAccessMode.APP_FOLDER) {
 		this.authProvider = authProvider;
@@ -26,7 +32,79 @@ export class OneDriveClient {
 	}
 
 	/**
-	 * Get the correct drive endpoint based on access mode
+	 * Configure the client for a shared/mounted folder on a different drive
+	 */
+	setRemoteDrive(driveId: string, itemId: string, rootName: string): void {
+		this.remoteDriveId = driveId;
+		this.remoteItemId = itemId;
+		this.remoteRootName = rootName;
+		logger.info(`Configured shared drive: driveId=${driveId}, itemId=${itemId}, rootName=${rootName}`);
+	}
+
+	/**
+	 * Check if operating on a shared/remote drive
+	 */
+	isSharedDrive(): boolean {
+		return !!(this.remoteDriveId && this.remoteItemId);
+	}
+
+	/**
+	 * Build a Graph API endpoint for a given remote path and optional suffix.
+	 * Handles app-folder, full-access, and shared-folder modes.
+	 *
+	 * @param rawPath - Unencoded path relative to the sync root (e.g. "subfolder/file.md").
+	 *                  May be empty for root operations.
+	 * @param suffix  - Optional Graph operation suffix (e.g. "content", "children", "createUploadSession", "delta")
+	 */
+	buildEndpoint(rawPath: string, suffix?: string): string {
+		// Normalize: strip leading/trailing slashes
+		const cleanPath = rawPath.replace(/^\/+|\/+$/g, '');
+		const encodedPath = cleanPath ? encodePathForGraph(cleanPath) : '';
+
+		if (this.isSharedDrive()) {
+			const base = `/drives/${this.remoteDriveId}/items/${this.remoteItemId}`;
+			if (!encodedPath) {
+				// Root of shared folder
+				return suffix ? `${base}/${suffix}` : base;
+			}
+			// Nested path within shared folder
+			return suffix
+				? `${base}:/${encodedPath}:/${suffix}`
+				: `${base}:/${encodedPath}`;
+		}
+
+		if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
+			const base = '/me/drive/special/approot';
+			if (!encodedPath) {
+				return suffix ? `${base}/${suffix}` : base;
+			}
+			return suffix
+				? `${base}:/${encodedPath}:/${suffix}`
+				: `${base}:/${encodedPath}`;
+		}
+
+		// Full access mode (non-shared)
+		const base = '/me/drive/root';
+		if (!encodedPath) {
+			return suffix ? `${base}/${suffix}` : base;
+		}
+		return suffix
+			? `${base}:/${encodedPath}:/${suffix}`
+			: `${base}:/${encodedPath}`;
+	}
+
+	/**
+	 * Build an endpoint for an item by ID, using the correct drive.
+	 */
+	getItemEndpoint(itemId: string): string {
+		if (this.remoteDriveId) {
+			return `/drives/${this.remoteDriveId}/items/${itemId}`;
+		}
+		return `/me/drive/items/${itemId}`;
+	}
+
+	/**
+	 * @deprecated Use buildEndpoint() instead. Kept for backward compat during migration.
 	 */
 	getDriveEndpoint(path: string): string {
 		if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
@@ -60,14 +138,13 @@ export class OneDriveClient {
 	}
 
 	/**
-	 * Get item by path
+	 * Get item by path (relative to sync root)
 	 */
 	async getItemByPath(path: string): Promise<OneDriveItem> {
 		logger.debug('Getting item by path:', path);
 
 		try {
-			const encodedPath = encodeURIComponent(path);
-			const endpoint = this.getDriveEndpoint(encodedPath);
+			const endpoint = this.buildEndpoint(path);
 			const response = await retryWithBackoff(() =>
 				this.client.api(endpoint).get()
 			);
@@ -82,25 +159,13 @@ export class OneDriveClient {
 	}
 
 	/**
-	 * List items in a folder
+	 * List items in a folder (path relative to sync root)
 	 */
 	async listFolder(folderPath: string = ''): Promise<OneDriveItem[]> {
 		logger.debug('Listing folder:', folderPath);
 
 		try {
-			let apiPath: string;
-			if (folderPath === '' || folderPath === '/') {
-				// List root
-				if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
-					apiPath = '/me/drive/special/approot/children';
-				} else {
-					apiPath = '/me/drive/root/children';
-				}
-			} else {
-				const encodedPath = encodeURIComponent(folderPath);
-				apiPath = `${this.getDriveEndpoint(encodedPath)}:/children`;
-			}
-
+			const apiPath = this.buildEndpoint(folderPath, 'children');
 			const response = await retryWithBackoff(() => this.client.api(apiPath).get());
 
 			return response.value as OneDriveItem[];
@@ -108,6 +173,38 @@ export class OneDriveClient {
 			logger.error(`Failed to list folder ${folderPath}:`, error);
 			throw new OneDriveError(
 				`Failed to list folder: ${error instanceof Error ? error.message : 'Unknown error'}`
+			);
+		}
+	}
+
+	/**
+	 * List folders at a specific path on the user's own drive.
+	 * Always uses /me/drive — ignores shared-folder configuration.
+	 * Used by the folder picker to browse the user's OneDrive.
+	 */
+	async listFoldersForPicker(folderPath: string = ''): Promise<OneDriveItem[]> {
+		logger.debug('Listing folders for picker:', folderPath);
+
+		try {
+			let apiPath: string;
+			const cleanPath = folderPath.replace(/^\/+|\/+$/g, '');
+
+			if (!cleanPath) {
+				apiPath = '/me/drive/root/children';
+			} else {
+				const encoded = encodePathForGraph(cleanPath);
+				apiPath = `/me/drive/root:/${encoded}:/children`;
+			}
+
+			const response = await retryWithBackoff(() => this.client.api(apiPath).get());
+			const items = response.value as OneDriveItem[];
+
+			// Return only folders (including shared/mounted shortcuts)
+			return items.filter((item) => item.folder || item.remoteItem?.folder);
+		} catch (error) {
+			logger.error(`Failed to list folders for picker at ${folderPath}:`, error);
+			throw new OneDriveError(
+				`Failed to list folders: ${error instanceof Error ? error.message : 'Unknown error'}`
 			);
 		}
 	}
@@ -142,17 +239,7 @@ export class OneDriveClient {
 		logger.debug('Creating folder:', folderPath, folderName);
 
 		try {
-			let apiPath: string;
-			if (folderPath === '' || folderPath === '/') {
-				if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
-					apiPath = '/me/drive/special/approot/children';
-				} else {
-					apiPath = '/me/drive/root/children';
-				}
-			} else {
-				const encodedPath = encodeURIComponent(folderPath);
-				apiPath = `${this.getDriveEndpoint(encodedPath)}:/children`;
-			}
+			const apiPath = this.buildEndpoint(folderPath, 'children');
 
 			const response = await retryWithBackoff(() =>
 				this.client.api(apiPath).post({
@@ -184,7 +271,7 @@ export class OneDriveClient {
 		logger.debug('Deleting item:', itemId);
 
 		try {
-			await retryWithBackoff(() => this.client.api(`/me/drive/items/${itemId}`).delete());
+			await retryWithBackoff(() => this.client.api(this.getItemEndpoint(itemId)).delete());
 			logger.debug('Item deleted successfully');
 		} catch (error) {
 			logger.error(`Failed to delete item ${itemId}:`, error);
@@ -203,7 +290,7 @@ export class OneDriveClient {
 		try {
 			// Get file metadata first to get download URL
 			const item: OneDriveItem = await retryWithBackoff(() =>
-				this.client.api(`/me/drive/items/${itemId}`).get()
+				this.client.api(this.getItemEndpoint(itemId)).get()
 			);
 
 			if (!item['@microsoft.graph.downloadUrl']) {
@@ -257,17 +344,17 @@ export class OneDriveClient {
 			if (deltaLink) {
 				// Use stored delta link for incremental changes
 				nextUrl = deltaLink;
+			} else if (this.isSharedDrive()) {
+				// Shared folder — delta scoped to the remote item
+				nextUrl = `/drives/${this.remoteDriveId}/items/${this.remoteItemId}/delta`;
+			} else if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
+				nextUrl = '/me/drive/special/approot/delta';
+			} else if (remotePath) {
+				const cleanPath = remotePath.replace(/^\//, '');
+				const encoded = encodePathForGraph(cleanPath);
+				nextUrl = `/me/drive/root:/${encoded}:/delta`;
 			} else {
-				// Initial sync — scope to the correct folder
-				if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
-					nextUrl = '/me/drive/special/approot/delta';
-				} else if (remotePath) {
-					// Scope delta to just the sync folder, not entire OneDrive
-					const encodedPath = remotePath.replace(/^\//, '');
-					nextUrl = `/me/drive/root:/${encodedPath}:/delta`;
-				} else {
-					nextUrl = '/me/drive/root/delta';
-				}
+				nextUrl = '/me/drive/root/delta';
 			}
 
 			// Page through all results
@@ -297,7 +384,7 @@ export class OneDriveClient {
 			if (deltaLink && error instanceof Error &&
 				(error.message.includes('resyncRequired') || error.message.includes('invalidToken'))) {
 				logger.warn('Delta token expired, performing full resync');
-				return this.getDelta(); // Retry without token
+				return this.getDelta(undefined, remotePath); // Retry without token
 			}
 
 			logger.error('Failed to get delta:', error);

--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -117,8 +117,10 @@ export class OneDriveClient {
 
 			const item = response as OneDriveItem;
 			// Build the full path from parentReference.path + name
-			// parentReference.path is like "/drive/root:" or "/drive/root:/Documents/ObsidianVaults"
+			// parentReference.path may be "/drive/root:" or "/drives/{id}/root:/some/path"
 			let parentPath = item.parentReference?.path || '';
+			// Strip all known Graph API prefixes
+			parentPath = parentPath.replace(/^\/drives\/[^/]+\/root:/, '');
 			parentPath = parentPath.replace(/^\/drive\/root:/, '');
 
 			const fullPath = parentPath ? `${parentPath}/${item.name}` : `/${item.name}`;

--- a/src/auth/deviceCodeFlow.ts
+++ b/src/auth/deviceCodeFlow.ts
@@ -22,10 +22,19 @@ import { parseHttpError } from '../utils/errors';
 import { sleep } from '../utils/retry';
 
 export class DeviceCodeFlowClient {
+	private cancelled = false;
+
 	constructor(
 		private clientId: string = DEFAULT_ONEDRIVE_CLIENT_ID,
 		private accessMode: OneDriveAccessMode = OneDriveAccessMode.APP_FOLDER
 	) {}
+
+	/**
+	 * Cancel any in-progress polling loop
+	 */
+	cancelPolling(): void {
+		this.cancelled = true;
+	}
 
 	/**
 	 * Request a device code from Microsoft
@@ -85,10 +94,16 @@ export class DeviceCodeFlowClient {
 	): Promise<TokenResponse> {
 		logger.debug('Starting token polling', { interval, expiresIn });
 
+		this.cancelled = false;
 		const startTime = Date.now();
 		const expiresAt = startTime + expiresIn * 1000;
 
 		while (Date.now() < expiresAt) {
+			if (this.cancelled) {
+				logger.info('Token polling cancelled');
+				throw new AuthenticationError('Authentication cancelled');
+			}
+
 			try {
 				const response = await requestUrl({
 					url: OAUTH_ENDPOINTS.TOKEN,
@@ -101,6 +116,7 @@ export class DeviceCodeFlowClient {
 						client_id: this.clientId,
 						device_code: deviceCode,
 					}).toString(),
+					throw: false,
 				});
 
 				if (response.status === 200) {
@@ -109,9 +125,9 @@ export class DeviceCodeFlowClient {
 					return data;
 				}
 
-				// Handle error responses
+				// Handle error responses (including 400s from Obsidian's requestUrl)
 				const errorData = response.json;
-				const errorCode = errorData.error;
+				const errorCode = errorData?.error;
 
 				if (errorCode === 'authorization_pending') {
 					// User hasn't completed auth yet, continue polling
@@ -127,7 +143,7 @@ export class DeviceCodeFlowClient {
 					throw new AuthenticationError('Device code expired. Please try again.');
 				} else {
 					throw new AuthenticationError(
-						`Authentication failed: ${errorData.error_description || errorCode}`
+						`Authentication failed: ${errorData?.error_description || errorCode || `HTTP ${response.status}`}`
 					);
 				}
 			} catch (error) {
@@ -137,7 +153,6 @@ export class DeviceCodeFlowClient {
 				// Network or temporary error - log but continue polling
 				logger.warn('Network error during token polling, will retry:', error);
 				if (onPending) onPending();
-				// Continue to next iteration instead of failing
 			}
 
 			// Wait before next poll

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,15 +135,14 @@ export default class OneDriveSyncPlugin extends Plugin {
 		// Add settings tab
 		this.addSettingTab(new OneDriveSettingTab(this.app, this));
 
-		// Start event listeners immediately — create events for known files
-		// are filtered deterministically via sync state, no timing needed
-		if (this.tokenStorage.hasTokens() && this.eventManager) {
+		// Start event listeners and periodic sync only if sync target is configured
+		if (this.tokenStorage.hasTokens() && this.eventManager && this.isSyncConfigured()) {
 			this.eventManager.startListening();
 			this.eventManager.startPeriodicSync(this.settings.syncInterval || 0);
 		}
 
-		// Perform startup sync if configured
-		if (this.tokenStorage.hasTokens() && this.settings.startupSyncDelay > 0) {
+		// Perform startup sync if configured and sync target is set
+		if (this.tokenStorage.hasTokens() && this.settings.startupSyncDelay > 0 && this.isSyncConfigured()) {
 			setTimeout(async () => {
 				await this.triggerManualSync();
 			}, this.settings.startupSyncDelay * 1000);
@@ -356,11 +355,26 @@ export default class OneDriveSyncPlugin extends Plugin {
 	}
 
 	/**
+	 * Check if sync target is fully configured
+	 */
+	private isSyncConfigured(): boolean {
+		if (this.settings.accessMode === OneDriveAccessMode.APP_FOLDER) {
+			return true; // App folder always has a fixed path
+		}
+		return !!this.settings.remotePath; // Full access needs a folder selected
+	}
+
+	/**
 	 * Trigger manual sync
 	 */
 	async triggerManualSync(): Promise<void> {
 		if (!this.tokenStorage.hasTokens()) {
 			new Notice('Not connected to OneDrive. Please connect in settings.');
+			return;
+		}
+
+		if (!this.isSyncConfigured()) {
+			new Notice('Please select a sync folder in settings first.');
 			return;
 		}
 
@@ -435,13 +449,18 @@ export default class OneDriveSyncPlugin extends Plugin {
 
 	/**
 	 * List folders at a path for the folder picker.
-	 * Always lists from the user's own OneDrive root (not scoped to shared drive).
+	 * Supports both the user's own drive and shared folder navigation.
 	 */
-	async listFoldersForPicker(path: string): Promise<OneDriveItem[]> {
+	async listFoldersForPicker(
+		path: string,
+		sharedDriveId?: string,
+		sharedItemId?: string,
+		relativePathInShared?: string
+	): Promise<OneDriveItem[]> {
 		if (!this.oneDriveClient) {
 			throw new Error('Not connected to OneDrive');
 		}
-		return this.oneDriveClient.listFoldersForPicker(path);
+		return this.oneDriveClient.listFoldersForPicker(path, sharedDriveId, sharedItemId, relativePathInShared);
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@
  */
 
 import { Plugin, Notice } from 'obsidian';
-import { PluginSettings, DEFAULT_SETTINGS, OneDriveAccessMode } from './types';
+import { PluginSettings, DEFAULT_SETTINGS, OneDriveAccessMode, OneDriveItem } from './types';
 import { DEFAULT_ONEDRIVE_CLIENT_ID, ONEDRIVE_PATHS } from './constants';
 import { logger } from './utils/logger';
 
@@ -27,6 +27,7 @@ import { EventManager } from './sync/eventManager';
 import { OneDriveSettingTab } from './ui/settings';
 import { StatusBarManager, SyncStatus } from './ui/statusBar';
 import { DeviceCodeModal } from './ui/authModal';
+import { FolderSelection } from './ui/folderBrowserModal';
 
 /**
  * Main plugin class
@@ -167,7 +168,7 @@ export default class OneDriveSyncPlugin extends Plugin {
 	 * Initialize authenticated components (API clients, sync engine)
 	 */
 	private async initializeAuthenticatedComponents() {
-		logger.debug('Initializing authenticated components');
+		logger.info(`Initializing authenticated components (mode: ${this.settings.accessMode})`);
 
 		try {
 			// Initialize auth provider
@@ -185,13 +186,30 @@ export default class OneDriveSyncPlugin extends Plugin {
 			this.oneDriveClient = new OneDriveClient(this.authProvider, this.settings.accessMode);
 			this.fileOps = new FileOperations(this.oneDriveClient);
 
+			// Configure shared drive if previously selected
+			if (this.settings.remoteDriveId && this.settings.remoteItemId && this.settings.remoteRootName) {
+				this.oneDriveClient.setRemoteDrive(
+					this.settings.remoteDriveId,
+					this.settings.remoteItemId,
+					this.settings.remoteRootName
+				);
+			}
+
 			// Initialize event manager — listening starts after initial sync
 			this.eventManager = new EventManager(this.app, async () => {
 				await this.performSync();
 			}, this.syncStateManager);
 
 			// Initialize sync engine
-			const remoteRoot = this.settings.remotePath || ONEDRIVE_PATHS.APP_FOLDER;
+			const isShared = this.oneDriveClient.isSharedDrive();
+			// For shared drives, upload paths are relative to the shared folder (no prefix needed).
+			// For non-shared, prepend the remote path.
+			const remoteRoot = isShared ? '' : (this.settings.remotePath || ONEDRIVE_PATHS.APP_FOLDER);
+			// For path stripping of delta responses, use the folder name on the remote drive
+			const remoteRootOnDrive = isShared
+				? `/${this.settings.remoteRootName}`
+				: undefined;
+
 			this.syncEngine = new SyncEngine(
 				this.app,
 				this.fileOps,
@@ -199,7 +217,8 @@ export default class OneDriveSyncPlugin extends Plugin {
 				this.syncStateManager,
 				this.conflictResolver,
 				this.eventManager,
-				remoteRoot
+				remoteRoot,
+				remoteRootOnDrive
 			);
 
 			// Get user info to display in settings
@@ -223,6 +242,16 @@ export default class OneDriveSyncPlugin extends Plugin {
 		logger.info('Starting authentication flow');
 
 		try {
+			// Cancel any in-progress polling from a previous auth attempt
+			this.deviceCodeClient.cancelPolling();
+
+			// Recreate the device code client so it uses the current access mode
+			const clientId = this.settings.useCustomClientId
+				? this.settings.customClientId || DEFAULT_ONEDRIVE_CLIENT_ID
+				: DEFAULT_ONEDRIVE_CLIENT_ID;
+			this.deviceCodeClient = new DeviceCodeFlowClient(clientId, this.settings.accessMode);
+			logger.info(`Authenticating with access mode: ${this.settings.accessMode}`);
+
 			let modalClosed = false;
 			let userCompleted = false;
 
@@ -266,6 +295,12 @@ export default class OneDriveSyncPlugin extends Plugin {
 			// Initialize authenticated components
 			await this.initializeAuthenticatedComponents();
 
+			// Start event listeners and periodic sync (not started in onload when no tokens exist)
+			if (this.eventManager) {
+				this.eventManager.startListening();
+				this.eventManager.startPeriodicSync(this.settings.syncInterval || 0);
+			}
+
 			// Update status bar
 			this.updateStatusBar();
 
@@ -286,6 +321,9 @@ export default class OneDriveSyncPlugin extends Plugin {
 	async disconnect(): Promise<void> {
 		logger.info('Disconnecting from OneDrive');
 
+		// Cancel any in-progress auth polling
+		this.deviceCodeClient.cancelPolling();
+
 		// Stop event manager
 		if (this.eventManager) {
 			this.eventManager.stopListening();
@@ -294,8 +332,11 @@ export default class OneDriveSyncPlugin extends Plugin {
 		// Clear tokens
 		this.tokenStorage.clearTokens();
 
-		// Clear user info
+		// Clear user info and shared drive settings
 		this.settings.connectedUser = undefined;
+		this.settings.remoteDriveId = undefined;
+		this.settings.remoteItemId = undefined;
+		this.settings.remoteRootName = undefined;
 
 		// Clear components
 		this.authProvider = undefined;
@@ -390,6 +431,60 @@ export default class OneDriveSyncPlugin extends Plugin {
 		} else {
 			this.statusBarManager.setStatus(SyncStatus.DISCONNECTED);
 		}
+	}
+
+	/**
+	 * List folders at a path for the folder picker.
+	 * Always lists from the user's own OneDrive root (not scoped to shared drive).
+	 */
+	async listFoldersForPicker(path: string): Promise<OneDriveItem[]> {
+		if (!this.oneDriveClient) {
+			throw new Error('Not connected to OneDrive');
+		}
+		return this.oneDriveClient.listFoldersForPicker(path);
+	}
+
+	/**
+	 * Called when the user selects a new remote folder from the picker.
+	 * Stores settings, clears stale sync state, and reconfigures components.
+	 */
+	async onRemoteFolderChanged(selection: FolderSelection): Promise<void> {
+		logger.info('Remote folder changed:', selection);
+
+		const oldPath = this.settings.remotePath;
+		const oldDriveId = this.settings.remoteDriveId;
+
+		this.settings.remotePath = selection.path;
+
+		if (selection.isShared && selection.driveId && selection.itemId) {
+			this.settings.remoteDriveId = selection.driveId;
+			this.settings.remoteItemId = selection.itemId;
+			this.settings.remoteRootName = selection.name;
+		} else {
+			this.settings.remoteDriveId = undefined;
+			this.settings.remoteItemId = undefined;
+			this.settings.remoteRootName = undefined;
+		}
+
+		// Clear stale sync state when the target folder changes
+		if (oldPath !== selection.path || oldDriveId !== this.settings.remoteDriveId) {
+			this.syncStateManager.clearState();
+			logger.info('Cleared sync state due to remote folder change');
+		}
+
+		await this.saveSettings();
+
+		// Reinitialize components with the new folder config
+		if (this.tokenStorage.hasTokens()) {
+			await this.initializeAuthenticatedComponents();
+
+			if (this.eventManager) {
+				this.eventManager.startListening();
+				this.eventManager.startPeriodicSync(this.settings.syncInterval || 0);
+			}
+		}
+
+		new Notice(`Sync folder set to: ${selection.path}${selection.isShared ? ' (shared)' : ''}`);
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -204,9 +204,9 @@ export default class OneDriveSyncPlugin extends Plugin {
 			// For shared drives, upload paths are relative to the shared folder (no prefix needed).
 			// For non-shared, prepend the remote path.
 			const remoteRoot = isShared ? '' : (this.settings.remotePath || ONEDRIVE_PATHS.APP_FOLDER);
-			// For path stripping of delta responses, use the folder name on the remote drive
+			// For path stripping of delta responses, use the actual path on the remote drive
 			const remoteRootOnDrive = isShared
-				? `/${this.settings.remoteRootName}`
+				? (this.settings.remoteRootPath || `/${this.settings.remoteRootName}`)
 				: undefined;
 
 			this.syncEngine = new SyncEngine(
@@ -336,6 +336,7 @@ export default class OneDriveSyncPlugin extends Plugin {
 		this.settings.remoteDriveId = undefined;
 		this.settings.remoteItemId = undefined;
 		this.settings.remoteRootName = undefined;
+		this.settings.remoteRootPath = undefined;
 
 		// Clear components
 		this.authProvider = undefined;
@@ -479,10 +480,25 @@ export default class OneDriveSyncPlugin extends Plugin {
 			this.settings.remoteDriveId = selection.driveId;
 			this.settings.remoteItemId = selection.itemId;
 			this.settings.remoteRootName = selection.name;
+
+			// Resolve the actual path on the remote drive for delta path stripping
+			if (this.oneDriveClient) {
+				try {
+					const resolvedPath = await this.oneDriveClient.resolveSharedFolderPath(
+						selection.driveId, selection.itemId
+					);
+					this.settings.remoteRootPath = resolvedPath;
+					logger.info(`Resolved shared folder path on remote drive: ${resolvedPath}`);
+				} catch (error) {
+					logger.warn('Could not resolve shared folder path, using name fallback:', error);
+					this.settings.remoteRootPath = `/${selection.name}`;
+				}
+			}
 		} else {
 			this.settings.remoteDriveId = undefined;
 			this.settings.remoteItemId = undefined;
 			this.settings.remoteRootName = undefined;
+			this.settings.remoteRootPath = undefined;
 		}
 
 		// Clear stale sync state when the target folder changes

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -19,7 +19,7 @@ import {
 	LocalChangeType,
 } from '../types';
 import { logger } from '../utils/logger';
-import { normalizePath, toOneDrivePath, toVaultPath, getParentPath } from '../utils/pathUtils';
+import { normalizePath, toOneDrivePath, toVaultPath, getParentPath, stripGraphPrefix } from '../utils/pathUtils';
 
 /**
  * Main sync engine
@@ -486,9 +486,7 @@ export class SyncEngine {
 		}
 
 		// Strip OneDrive API prefixes
-		fullPath = fullPath.replace(/^\/drive\/root:/, '');
-		fullPath = fullPath.replace(/^\/drive\/special\/approot:/, '');
-		fullPath = fullPath.replace(/^\/drives\/[^/]+\/root:/, '');
+		fullPath = stripGraphPrefix(fullPath);
 
 		return toVaultPath(fullPath, this.remoteRootOnDrive);
 	}

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -108,6 +108,10 @@ export class SyncEngine {
 			// 4. Execute operations
 			let completed = 0;
 			const downloadedPaths: string[] = [];
+			// Single persistent notice for progress — updates in place
+			const progressNotice = operations.length >= 5
+				? new Notice(`Syncing: 0/${operations.length} files...`, 0)
+				: null;
 			for (const operation of operations) {
 				await this.executeOperation(operation);
 				completed++;
@@ -116,10 +120,12 @@ export class SyncEngine {
 					downloadedPaths.push(operation.path);
 				}
 
-				if (operations.length > 5) {
-					new Notice(`Syncing: ${completed}/${operations.length} files`, 2000);
+				if (progressNotice) {
+					progressNotice.setMessage(`Syncing: ${completed}/${operations.length} files...`);
 				}
 			}
+			// Dismiss progress notice
+			progressNotice?.hide();
 
 			// Clear any dirty-file entries for paths we just downloaded,
 			// so they don't boomerang back as uploads on the next cycle
@@ -131,8 +137,8 @@ export class SyncEngine {
 			this.stateManager.setDeltaLink(deltaResponse.deltaLink);
 			this.stateManager.setLastSyncTime(Date.now());
 
-				// Clear dirty files only after successful sync
-				this.eventManager.clearDirtyFiles();
+			// Clear dirty files only after successful sync
+			this.eventManager.clearDirtyFiles();
 
 			logger.info('Sync completed successfully');
 			new Notice(`OneDrive sync: ${completed} file${completed === 1 ? '' : 's'} synced`);
@@ -469,9 +475,15 @@ export class SyncEngine {
 	 * Convert remote OneDrive path to vault path
 	 */
 	private remotePathToVaultPath(item: OneDriveItem): string {
-		let fullPath = item.parentReference?.path
-			? `${item.parentReference.path}/${item.name}`
-			: item.name;
+		let fullPath: string;
+		if (item.parentReference?.path && item.name) {
+			fullPath = `${item.parentReference.path}/${item.name}`;
+		} else if (item.name) {
+			fullPath = item.name;
+		} else {
+			// Deleted or root items may lack name/path
+			return '';
+		}
 
 		// Strip OneDrive API prefixes
 		fullPath = fullPath.replace(/^\/drive\/root:/, '');

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -25,6 +25,9 @@ import { normalizePath, toOneDrivePath, toVaultPath, getParentPath } from '../ut
  * Main sync engine
  */
 export class SyncEngine {
+	private isSharedDrive: boolean;
+	private remoteRootOnDrive: string;
+
 	constructor(
 		private app: App,
 		private fileOps: FileOperations,
@@ -32,8 +35,14 @@ export class SyncEngine {
 		private stateManager: SyncStateManager,
 		private conflictResolver: ConflictResolver,
 		private eventManager: EventManager,
-		private remoteRoot: string = ''
-	) {}
+		private remoteRoot: string = '',
+		remoteRootOnDrive?: string
+	) {
+		this.isSharedDrive = oneDriveClient.isSharedDrive();
+		// For shared drives, delta items have paths relative to the remote drive root,
+		// so we need the folder name on that drive for path stripping
+		this.remoteRootOnDrive = remoteRootOnDrive || remoteRoot;
+	}
 
 	/**
 	 * Perform a sync using delta API + local dirty files
@@ -44,11 +53,15 @@ export class SyncEngine {
 		try {
 			// 1. Get local changes from event manager
 			const localChanges = this.eventManager.getDirtyFiles();
-			logger.debug(`Local changes: ${localChanges.length}`);
+			logger.info(`Local changes: ${localChanges.length} dirty files`);
+			for (const change of localChanges) {
+				logger.info(`  Local: ${change.type} ${change.path}${change.oldPath ? ` (from ${change.oldPath})` : ''}`);
+			}
 
 			// 2. Get remote changes via delta API
 			const deltaLink = this.stateManager.getDeltaLink();
 			const isFirstSync = this.stateManager.isFirstSync();
+			logger.info(`Delta query: isFirstSync=${isFirstSync}, hasDeltaLink=${!!deltaLink}`);
 			const deltaResponse = await this.oneDriveClient.getDelta(deltaLink, this.remoteRoot);
 
 			// Log all raw delta items for debugging
@@ -65,18 +78,27 @@ export class SyncEngine {
 				return !vaultPath.startsWith('.obsidian/');
 			});
 
-			logger.debug(`Delta returned ${deltaResponse.items.length} total items, ${remoteChanges.length} file changes`);
+			logger.info(`Delta returned ${deltaResponse.items.length} total items, ${remoteChanges.length} file changes`);
 			for (const item of remoteChanges) {
 				const vaultPath = this.remotePathToVaultPath(item);
-				logger.debug(`  Remote item: ${vaultPath} deleted=${!!item.deleted} hash=${item.file?.hashes?.quickXorHash || 'none'} id=${item.id}`);
+				logger.info(`  Remote: ${item.deleted ? 'DELETE' : 'CHANGED'} ${vaultPath} (id=${item.id})`);
 			}
 
 			// 3. Plan operations
 			const operations = this.planOperations(localChanges, remoteChanges, isFirstSync);
 
 			logger.info(`Sync plan: ${operations.length} operations`);
+			for (const op of operations) {
+				logger.info(`  Op: ${op.direction} ${op.path}`);
+			}
 
 			if (operations.length === 0) {
+				if (isFirstSync && localChanges.length === 0 && remoteChanges.length === 0) {
+					logger.info('First sync with no local dirty files and empty remote — nothing to do. Edit or create files, then sync again.');
+					new Notice('OneDrive sync: No files to sync. Edit or create files first.');
+				} else {
+					new Notice('OneDrive sync: Everything up to date');
+				}
 				// Store delta link and update sync time even with no changes
 				this.stateManager.setDeltaLink(deltaResponse.deltaLink);
 				this.stateManager.setLastSyncTime(Date.now());
@@ -115,8 +137,9 @@ export class SyncEngine {
 			logger.info('Sync completed successfully');
 			new Notice(`OneDrive sync: ${completed} file${completed === 1 ? '' : 's'} synced`);
 		} catch (error) {
-			logger.error('Sync failed:', error);
-			new Notice('OneDrive sync failed. Check console for details.');
+			const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+			logger.error(`Sync failed: ${errorMsg}`, error);
+			new Notice(`OneDrive sync failed: ${errorMsg}`);
 			throw error;
 		}
 	}
@@ -430,9 +453,15 @@ export class SyncEngine {
 	}
 
 	/**
-	 * Convert vault path to remote OneDrive path
+	 * Convert vault path to remote OneDrive path.
+	 * For shared drives, paths are relative to the shared folder (no prefix).
+	 * For non-shared full-access, paths include the remote root.
 	 */
 	private vaultPathToRemotePath(vaultPath: string): string {
+		if (this.isSharedDrive) {
+			// Paths are relative to the shared folder — buildEndpoint handles the base
+			return normalizePath(vaultPath);
+		}
 		return toOneDrivePath(vaultPath, this.remoteRoot);
 	}
 
@@ -444,10 +473,11 @@ export class SyncEngine {
 			? `${item.parentReference.path}/${item.name}`
 			: item.name;
 
-		// Strip OneDrive API prefix if present
+		// Strip OneDrive API prefixes
 		fullPath = fullPath.replace(/^\/drive\/root:/, '');
 		fullPath = fullPath.replace(/^\/drive\/special\/approot:/, '');
+		fullPath = fullPath.replace(/^\/drives\/[^/]+\/root:/, '');
 
-		return toVaultPath(fullPath, this.remoteRoot);
+		return toVaultPath(fullPath, this.remoteRootOnDrive);
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -178,7 +178,8 @@ export interface PluginSettings {
 	remotePath?: string; // Custom path (only used with Full Access mode)
 	remoteDriveId?: string; // Drive ID for shared/mounted folders
 	remoteItemId?: string; // Item ID of the root folder on the remote drive
-	remoteRootName?: string; // Name of the root folder on the remote drive
+	remoteRootName?: string; // Display name of the root folder on the remote drive
+	remoteRootPath?: string; // Full path of the folder on the remote drive (e.g. /Documents/ObsidianVaults/JeffBrain)
 	enableDebugLogging: boolean;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,17 @@ export interface OneDriveItem {
 	parentReference?: {
 		id: string;
 		path: string;
+		driveId?: string;
+	};
+	remoteItem?: {
+		id: string;
+		name: string;
+		folder?: { childCount: number };
+		parentReference: {
+			driveId: string;
+			id?: string;
+			path?: string;
+		};
 	};
 }
 
@@ -165,6 +176,9 @@ export interface PluginSettings {
 
 	// Advanced
 	remotePath?: string; // Custom path (only used with Full Access mode)
+	remoteDriveId?: string; // Drive ID for shared/mounted folders
+	remoteItemId?: string; // Item ID of the root folder on the remote drive
+	remoteRootName?: string; // Name of the root folder on the remote drive
 	enableDebugLogging: boolean;
 }
 

--- a/src/ui/folderBrowserModal.ts
+++ b/src/ui/folderBrowserModal.ts
@@ -1,0 +1,205 @@
+/**
+ * Modal for browsing and selecting OneDrive folders
+ */
+
+import { App, Modal, Setting } from 'obsidian';
+import { OneDriveItem } from '../types';
+
+export interface FolderSelection {
+	path: string;
+	name: string;
+	isShared: boolean;
+	driveId?: string;
+	itemId?: string;
+}
+
+type FolderListFn = (path: string) => Promise<OneDriveItem[]>;
+
+/**
+ * Modal that lets the user browse OneDrive folders and select one
+ */
+export class FolderBrowserModal extends Modal {
+	private currentPath: string[] = [];
+	private onSelect: (selection: FolderSelection) => void;
+	private listFolders: FolderListFn;
+	private contentEl_body: HTMLElement;
+	private loading = false;
+
+	// Track the shared folder info if the user navigated into one at the top level
+	private sharedDriveId?: string;
+	private sharedItemId?: string;
+	private sharedAtDepth?: number; // depth at which the shared folder was entered
+
+	constructor(
+		app: App,
+		listFolders: FolderListFn,
+		onSelect: (selection: FolderSelection) => void,
+		initialPath?: string
+	) {
+		super(app);
+		this.listFolders = listFolders;
+		this.onSelect = onSelect;
+
+		if (initialPath) {
+			this.currentPath = initialPath.split('/').filter((s) => s.length > 0);
+		}
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('onedrive-folder-browser');
+
+		contentEl.createEl('h3', { text: 'Select OneDrive Folder' });
+
+		this.contentEl_body = contentEl.createDiv({ cls: 'folder-browser-body' });
+		this.contentEl_body.style.minHeight = '200px';
+		this.contentEl_body.style.maxHeight = '400px';
+		this.contentEl_body.style.overflowY = 'auto';
+
+		this.loadFolder();
+	}
+
+	onClose() {
+		this.contentEl.empty();
+	}
+
+	private get currentPathStr(): string {
+		return this.currentPath.length > 0 ? this.currentPath.join('/') : '';
+	}
+
+	private async loadFolder() {
+		if (this.loading) return;
+		this.loading = true;
+
+		const body = this.contentEl_body;
+		body.empty();
+
+		// Breadcrumb
+		const breadcrumb = body.createDiv({ cls: 'folder-breadcrumb' });
+		breadcrumb.style.marginBottom = '8px';
+		breadcrumb.style.fontSize = '13px';
+		breadcrumb.style.color = 'var(--text-muted)';
+		breadcrumb.style.display = 'flex';
+		breadcrumb.style.alignItems = 'center';
+		breadcrumb.style.flexWrap = 'wrap';
+		breadcrumb.style.gap = '2px';
+
+		// Root link
+		const rootLink = breadcrumb.createEl('span', { text: '📁 OneDrive' });
+		rootLink.style.cursor = 'pointer';
+		rootLink.style.color = 'var(--text-accent)';
+		rootLink.onclick = () => {
+			this.currentPath = [];
+			this.sharedDriveId = undefined;
+			this.sharedItemId = undefined;
+			this.sharedAtDepth = undefined;
+			this.loadFolder();
+		};
+
+		for (let i = 0; i < this.currentPath.length; i++) {
+			breadcrumb.createEl('span', { text: ' / ' });
+			const seg = breadcrumb.createEl('span', { text: this.currentPath[i] });
+			if (i < this.currentPath.length - 1) {
+				seg.style.cursor = 'pointer';
+				seg.style.color = 'var(--text-accent)';
+				const depth = i;
+				seg.onclick = () => {
+					this.currentPath = this.currentPath.slice(0, depth + 1);
+					if (this.sharedAtDepth !== undefined && depth < this.sharedAtDepth) {
+						this.sharedDriveId = undefined;
+						this.sharedItemId = undefined;
+						this.sharedAtDepth = undefined;
+					}
+					this.loadFolder();
+				};
+			}
+		}
+
+		// Select button for current folder
+		if (this.currentPath.length > 0) {
+			const selectRow = body.createDiv();
+			selectRow.style.marginBottom = '12px';
+			new Setting(selectRow)
+				.setName(`Select "/${this.currentPath.join('/')}"`)
+				.addButton((btn) =>
+					btn.setButtonText('Use this folder').setCta().onClick(() => {
+						const isShared = !!(this.sharedDriveId && this.sharedItemId);
+						this.onSelect({
+							path: `/${this.currentPath.join('/')}`,
+							name: this.currentPath[this.currentPath.length - 1],
+							isShared,
+							driveId: this.sharedDriveId,
+							itemId: this.sharedItemId,
+						});
+						this.close();
+					})
+				);
+		}
+
+		// Loading indicator
+		const loadingEl = body.createDiv({ text: 'Loading folders...' });
+		loadingEl.style.color = 'var(--text-muted)';
+		loadingEl.style.fontStyle = 'italic';
+
+		try {
+			const folders = await this.listFolders(this.currentPathStr);
+
+			loadingEl.remove();
+
+			if (folders.length === 0) {
+				const emptyEl = body.createDiv({ text: 'No subfolders' });
+				emptyEl.style.color = 'var(--text-muted)';
+				emptyEl.style.fontStyle = 'italic';
+				emptyEl.style.padding = '8px 0';
+			}
+
+			for (const folder of folders) {
+				const isShared = !!folder.remoteItem;
+				const name = folder.name;
+				const childCount = folder.folder?.childCount ?? folder.remoteItem?.folder?.childCount ?? 0;
+
+				const row = body.createDiv({ cls: 'folder-row' });
+				row.style.display = 'flex';
+				row.style.alignItems = 'center';
+				row.style.padding = '6px 8px';
+				row.style.cursor = 'pointer';
+				row.style.borderRadius = '4px';
+
+				row.onmouseenter = () => { row.style.backgroundColor = 'var(--background-modifier-hover)'; };
+				row.onmouseleave = () => { row.style.backgroundColor = ''; };
+
+				const icon = isShared ? '🔗' : '📁';
+				row.createEl('span', { text: `${icon} ${name}` });
+
+				const meta = row.createEl('span');
+				meta.style.marginLeft = 'auto';
+				meta.style.fontSize = '12px';
+				meta.style.color = 'var(--text-muted)';
+				const parts: string[] = [];
+				if (isShared) parts.push('shared');
+				if (childCount > 0) parts.push(`${childCount} items`);
+				meta.textContent = parts.join(' · ');
+
+				row.onclick = () => {
+					// If this is a shared/remote item at this level, capture its drive info
+					if (isShared && folder.remoteItem) {
+						this.sharedDriveId = folder.remoteItem.parentReference.driveId;
+						this.sharedItemId = folder.remoteItem.id;
+						this.sharedAtDepth = this.currentPath.length;
+					}
+					this.currentPath.push(name);
+					this.loadFolder();
+				};
+			}
+		} catch (error) {
+			loadingEl.remove();
+			const errorEl = body.createDiv({
+				text: `Error loading folders: ${error instanceof Error ? error.message : 'Unknown error'}`,
+			});
+			errorEl.style.color = 'var(--text-error)';
+		}
+
+		this.loading = false;
+	}
+}

--- a/src/ui/folderBrowserModal.ts
+++ b/src/ui/folderBrowserModal.ts
@@ -13,7 +13,12 @@ export interface FolderSelection {
 	itemId?: string;
 }
 
-type FolderListFn = (path: string) => Promise<OneDriveItem[]>;
+type FolderListFn = (
+	path: string,
+	sharedDriveId?: string,
+	sharedItemId?: string,
+	relativePathInShared?: string
+) => Promise<OneDriveItem[]>;
 
 /**
  * Modal that lets the user browse OneDrive folders and select one
@@ -25,7 +30,7 @@ export class FolderBrowserModal extends Modal {
 	private contentEl_body: HTMLElement;
 	private loading = false;
 
-	// Track the shared folder info if the user navigated into one at the top level
+	// Track the shared folder info if the user navigated into one
 	private sharedDriveId?: string;
 	private sharedItemId?: string;
 	private sharedAtDepth?: number; // depth at which the shared folder was entered
@@ -66,6 +71,15 @@ export class FolderBrowserModal extends Modal {
 
 	private get currentPathStr(): string {
 		return this.currentPath.length > 0 ? this.currentPath.join('/') : '';
+	}
+
+	/**
+	 * Get the relative path within the shared folder (segments after sharedAtDepth + 1)
+	 */
+	private get relativePathInShared(): string {
+		if (this.sharedAtDepth === undefined) return '';
+		const segments = this.currentPath.slice(this.sharedAtDepth + 1);
+		return segments.join('/');
 	}
 
 	private async loadFolder() {
@@ -127,7 +141,7 @@ export class FolderBrowserModal extends Modal {
 						const isShared = !!(this.sharedDriveId && this.sharedItemId);
 						this.onSelect({
 							path: `/${this.currentPath.join('/')}`,
-							name: this.currentPath[this.currentPath.length - 1],
+							name: this.currentPath[this.sharedAtDepth ?? this.currentPath.length - 1],
 							isShared,
 							driveId: this.sharedDriveId,
 							itemId: this.sharedItemId,
@@ -143,7 +157,20 @@ export class FolderBrowserModal extends Modal {
 		loadingEl.style.fontStyle = 'italic';
 
 		try {
-			const folders = await this.listFolders(this.currentPathStr);
+			let folders: OneDriveItem[];
+
+			if (this.sharedDriveId && this.sharedItemId) {
+				// Inside a shared folder — use remote drive API
+				folders = await this.listFolders(
+					this.currentPathStr,
+					this.sharedDriveId,
+					this.sharedItemId,
+					this.relativePathInShared
+				);
+			} else {
+				// User's own drive
+				folders = await this.listFolders(this.currentPathStr);
+			}
 
 			loadingEl.remove();
 
@@ -182,7 +209,7 @@ export class FolderBrowserModal extends Modal {
 				meta.textContent = parts.join(' · ');
 
 				row.onclick = () => {
-					// If this is a shared/remote item at this level, capture its drive info
+					// If this is a shared/remote item, capture its drive info
 					if (isShared && folder.remoteItem) {
 						this.sharedDriveId = folder.remoteItem.parentReference.driveId;
 						this.sharedItemId = folder.remoteItem.id;

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -174,8 +174,7 @@ export class OneDriveSettingTab extends PluginSettingTab {
 								async (selection: FolderSelection) => {
 									await this.plugin.onRemoteFolderChanged(selection);
 									this.display(); // Refresh to show new selection
-								},
-								this.plugin.settings.remotePath || undefined
+								}
 							);
 							modal.open();
 						})

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -3,8 +3,9 @@
  */
 
 import { App, PluginSettingTab, Setting, Notice } from 'obsidian';
-import { PluginSettings, ConflictResolutionStrategy, OneDriveAccessMode } from '../types';
+import { PluginSettings, ConflictResolutionStrategy, OneDriveAccessMode, OneDriveItem } from '../types';
 import { DEFAULT_ONEDRIVE_CLIENT_ID } from '../constants';
+import { FolderBrowserModal, FolderSelection } from './folderBrowserModal';
 
 // Forward declaration for the plugin type
 interface OneDrivePlugin {
@@ -14,6 +15,8 @@ interface OneDrivePlugin {
 	authenticate(): Promise<void>;
 	disconnect(): void;
 	triggerManualSync(): Promise<void>;
+	listFoldersForPicker(path: string): Promise<OneDriveItem[]>;
+	onRemoteFolderChanged(selection: FolderSelection): Promise<void>;
 }
 
 /**
@@ -119,8 +122,10 @@ export class OneDriveSettingTab extends PluginSettingTab {
 	private displayAccessModeSection(containerEl: HTMLElement): void {
 		containerEl.createEl('h3', { text: 'Access Mode' });
 
+		const isConnected = !!this.plugin.settings.connectedUser;
+
 		// Warning text right below heading
-		if (this.plugin.settings.connectedUser) {
+		if (isConnected) {
 			const warningEl = containerEl.createEl('p');
 			warningEl.style.color = 'var(--text-error)';
 			warningEl.style.fontSize = '12px';
@@ -129,7 +134,7 @@ export class OneDriveSettingTab extends PluginSettingTab {
 			warningEl.textContent = 'Changing access mode requires disconnecting and reconnecting.';
 		}
 
-		// Access mode selector — combined with sync folder path in one group
+		// Access mode selector
 		const accessGroup = containerEl.createDiv();
 
 		new Setting(accessGroup)
@@ -148,19 +153,37 @@ export class OneDriveSettingTab extends PluginSettingTab {
 			);
 
 		if (this.plugin.settings.accessMode === OneDriveAccessMode.FULL_ACCESS) {
-			new Setting(accessGroup)
-				.setName('Sync folder path')
-				.setDesc('OneDrive folder where your vault will be synced')
-				.addText((text) => {
-					text
-						.setPlaceholder('/Documents/MyVault')
-						.setValue(this.plugin.settings.remotePath || '/Documents/ObsidianVault')
-						.onChange(async (value) => {
-							this.plugin.settings.remotePath = value;
-							await this.plugin.saveSettings();
-						});
-					text.inputEl.style.width = '300px';
-				});
+			if (isConnected) {
+				// Show folder picker (browse button + current selection)
+				const currentPath = this.plugin.settings.remotePath || '(not selected)';
+				const isShared = !!this.plugin.settings.remoteDriveId;
+				const desc = isShared
+					? `${currentPath} (shared folder)`
+					: currentPath;
+
+				new Setting(accessGroup)
+					.setName('Sync folder')
+					.setDesc(desc)
+					.addButton((btn) =>
+						btn.setButtonText('Browse...').onClick(() => {
+							const modal = new FolderBrowserModal(
+								this.app,
+								(path: string) => this.plugin.listFoldersForPicker(path),
+								async (selection: FolderSelection) => {
+									await this.plugin.onRemoteFolderChanged(selection);
+									this.display(); // Refresh to show new selection
+								},
+								this.plugin.settings.remotePath || undefined
+							);
+							modal.open();
+						})
+					);
+			} else {
+				// Not connected — just show a note
+				const noteEl = accessGroup.createEl('p', { cls: 'setting-item-description' });
+				noteEl.style.margin = '0 0 12px 0';
+				noteEl.textContent = 'Connect to OneDrive first, then select a sync folder.';
+			}
 
 			const descEl = containerEl.createEl('p', { cls: 'setting-item-description' });
 			descEl.style.margin = '0 0 12px 0';

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -15,7 +15,12 @@ interface OneDrivePlugin {
 	authenticate(): Promise<void>;
 	disconnect(): void;
 	triggerManualSync(): Promise<void>;
-	listFoldersForPicker(path: string): Promise<OneDriveItem[]>;
+	listFoldersForPicker(
+		path: string,
+		sharedDriveId?: string,
+		sharedItemId?: string,
+		relativePathInShared?: string
+	): Promise<OneDriveItem[]>;
 	onRemoteFolderChanged(selection: FolderSelection): Promise<void>;
 }
 
@@ -83,16 +88,6 @@ export class OneDriveSettingTab extends PluginSettingTab {
 						this.display(); // Refresh settings
 					})
 			);
-
-			// Manual sync button
-			statusSetting.addButton((button) =>
-				button
-					.setButtonText('Sync Now')
-					.setCta()
-					.onClick(async () => {
-						await this.plugin.triggerManualSync();
-					})
-			);
 		} else {
 			statusSetting.setDesc('Not connected');
 
@@ -152,6 +147,12 @@ export class OneDriveSettingTab extends PluginSettingTab {
 					})
 			);
 
+		// Determine if sync is ready (folder selected or app-folder mode)
+		const isSyncReady = isConnected && (
+			this.plugin.settings.accessMode === OneDriveAccessMode.APP_FOLDER ||
+			!!this.plugin.settings.remotePath
+		);
+
 		if (this.plugin.settings.accessMode === OneDriveAccessMode.FULL_ACCESS) {
 			if (isConnected) {
 				// Show folder picker (browse button + current selection)
@@ -161,14 +162,15 @@ export class OneDriveSettingTab extends PluginSettingTab {
 					? `${currentPath} (shared folder)`
 					: currentPath;
 
-				new Setting(accessGroup)
+				const folderSetting = new Setting(accessGroup)
 					.setName('Sync folder')
 					.setDesc(desc)
 					.addButton((btn) =>
 						btn.setButtonText('Browse...').onClick(() => {
 							const modal = new FolderBrowserModal(
 								this.app,
-								(path: string) => this.plugin.listFoldersForPicker(path),
+								(path, sharedDriveId?, sharedItemId?, relPath?) =>
+									this.plugin.listFoldersForPicker(path, sharedDriveId, sharedItemId, relPath),
 								async (selection: FolderSelection) => {
 									await this.plugin.onRemoteFolderChanged(selection);
 									this.display(); // Refresh to show new selection
@@ -178,6 +180,15 @@ export class OneDriveSettingTab extends PluginSettingTab {
 							modal.open();
 						})
 					);
+
+				// Sync Now button — only when a folder is selected
+				if (this.plugin.settings.remotePath) {
+					folderSetting.addButton((btn) =>
+						btn.setButtonText('Sync Now').setCta().onClick(async () => {
+							await this.plugin.triggerManualSync();
+						})
+					);
+				}
 			} else {
 				// Not connected — just show a note
 				const noteEl = accessGroup.createEl('p', { cls: 'setting-item-description' });
@@ -192,6 +203,16 @@ export class OneDriveSettingTab extends PluginSettingTab {
 			const descEl = containerEl.createEl('p', { cls: 'setting-item-description' });
 			descEl.style.margin = '0 0 12px 0';
 			descEl.innerHTML = `Secure isolated folder at <code>/Apps/ObsidianOneDrive/</code>. No configuration needed, but can't sync to existing folders.`;
+
+			// Sync Now for app-folder mode
+			if (isConnected) {
+				new Setting(accessGroup)
+					.addButton((btn) =>
+						btn.setButtonText('Sync Now').setCta().onClick(async () => {
+							await this.plugin.triggerManualSync();
+						})
+					);
+			}
 		}
 	}
 

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -128,6 +128,18 @@ export function toVaultPath(oneDrivePath: string, remoteRoot: string): string {
 }
 
 /**
+ * Strip Microsoft Graph API prefixes from a path.
+ * Handles /drive/root:, /drive/special/approot:, and /drives/{driveId}/root: prefixes.
+ */
+export function stripGraphPrefix(path: string): string {
+	let result = path;
+	result = result.replace(/^\/drives\/[^/]+\/root:/, '');
+	result = result.replace(/^\/drive\/root:/, '');
+	result = result.replace(/^\/drive\/special\/approot:/, '');
+	return result;
+}
+
+/**
  * Check if path is within root directory
  */
 export function isPathWithinRoot(path: string, root: string): boolean {

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -86,6 +86,18 @@ export function sanitizeFileName(name: string): string {
 }
 
 /**
+ * Encode a file path for use in Microsoft Graph API URLs.
+ * Encodes each segment individually so slashes are preserved.
+ */
+export function encodePathForGraph(path: string): string {
+	return path
+		.split('/')
+		.filter((s) => s.length > 0)
+		.map((segment) => encodeURIComponent(segment))
+		.join('/');
+}
+
+/**
  * Convert vault path to OneDrive path
  */
 export function toOneDrivePath(vaultPath: string, remoteRoot: string): string {

--- a/tests/unit/utils/pathUtils.test.ts
+++ b/tests/unit/utils/pathUtils.test.ts
@@ -14,6 +14,8 @@ import {
 	createConflictFileName,
 	toOneDrivePath,
 	toVaultPath,
+	encodePathForGraph,
+	stripGraphPrefix,
 } from '../../../src/utils/pathUtils';
 
 describe('pathUtils', () => {
@@ -131,6 +133,128 @@ describe('pathUtils', () => {
 
 		it('should return path as-is if not under root', () => {
 			expect(toVaultPath('/other/file.md', '/vault')).toBe('/other/file.md');
+		});
+
+		it('should handle shared drive paths after prefix stripping', () => {
+			// After stripGraphPrefix removes /drives/{id}/root:, the remaining path
+			// needs to have the shared folder root stripped
+			const pathAfterStrip = '/Documents/ObsidianVaults/JeffBrain/notes/daily.md';
+			const remoteRoot = '/Documents/ObsidianVaults/JeffBrain';
+			expect(toVaultPath(pathAfterStrip, remoteRoot)).toBe('notes/daily.md');
+		});
+
+		it('should handle root-level files in shared folder', () => {
+			const pathAfterStrip = '/Documents/ObsidianVaults/JeffBrain/Welcome.md';
+			const remoteRoot = '/Documents/ObsidianVaults/JeffBrain';
+			expect(toVaultPath(pathAfterStrip, remoteRoot)).toBe('Welcome.md');
+		});
+
+		it('should handle .obsidian paths for filtering', () => {
+			const pathAfterStrip = '/Documents/ObsidianVaults/JeffBrain/.obsidian/app.json';
+			const remoteRoot = '/Documents/ObsidianVaults/JeffBrain';
+			const vaultPath = toVaultPath(pathAfterStrip, remoteRoot);
+			expect(vaultPath).toBe('.obsidian/app.json');
+			expect(vaultPath.startsWith('.obsidian/')).toBe(true);
+		});
+
+		it('should handle empty remote root', () => {
+			expect(toVaultPath('notes/file.md', '')).toBe('notes/file.md');
+		});
+	});
+
+	describe('encodePathForGraph', () => {
+		it('should encode individual path segments', () => {
+			expect(encodePathForGraph('/JeffBrain/file.md')).toBe('JeffBrain/file.md');
+		});
+
+		it('should encode special characters in segments', () => {
+			expect(encodePathForGraph('/My Folder/file name.md')).toBe('My%20Folder/file%20name.md');
+		});
+
+		it('should preserve slashes between segments', () => {
+			expect(encodePathForGraph('/a/b/c/d.txt')).toBe('a/b/c/d.txt');
+		});
+
+		it('should encode hash and question mark', () => {
+			expect(encodePathForGraph('/notes/file#1.md')).toBe('notes/file%231.md');
+		});
+
+		it('should handle single segment', () => {
+			expect(encodePathForGraph('file.md')).toBe('file.md');
+		});
+
+		it('should handle empty path', () => {
+			expect(encodePathForGraph('')).toBe('');
+		});
+	});
+
+	describe('stripGraphPrefix', () => {
+		it('should strip /drive/root: prefix', () => {
+			expect(stripGraphPrefix('/drive/root:/Documents/file.md')).toBe('/Documents/file.md');
+		});
+
+		it('should strip /drive/special/approot: prefix', () => {
+			expect(stripGraphPrefix('/drive/special/approot:/notes/file.md')).toBe('/notes/file.md');
+		});
+
+		it('should strip /drives/{driveId}/root: prefix', () => {
+			expect(stripGraphPrefix('/drives/48043224b16ff524/root:/Documents/ObsidianVaults/JeffBrain/file.md'))
+				.toBe('/Documents/ObsidianVaults/JeffBrain/file.md');
+		});
+
+		it('should handle uppercase drive IDs', () => {
+			expect(stripGraphPrefix('/drives/48043224B16FF524/root:/Documents/file.md'))
+				.toBe('/Documents/file.md');
+		});
+
+		it('should handle alphanumeric+special drive IDs', () => {
+			expect(stripGraphPrefix('/drives/ABC123!def/root:/file.md'))
+				.toBe('/file.md');
+		});
+
+		it('should return path unchanged if no prefix matches', () => {
+			expect(stripGraphPrefix('/Documents/file.md')).toBe('/Documents/file.md');
+		});
+
+		it('should return empty-ish path for root-only prefix', () => {
+			expect(stripGraphPrefix('/drive/root:')).toBe('');
+		});
+
+		it('should handle full shared drive delta path end-to-end', () => {
+			// Simulates what remotePathToVaultPath does:
+			// 1. Delta item has parentReference.path + name
+			const parentPath = '/drives/48043224B16FF524/root:/Documents/ObsidianVaults/JeffBrain';
+			const name = 'Welcome.md';
+			const fullPath = `${parentPath}/${name}`;
+			
+			// 2. Strip the Graph prefix
+			const stripped = stripGraphPrefix(fullPath);
+			expect(stripped).toBe('/Documents/ObsidianVaults/JeffBrain/Welcome.md');
+			
+			// 3. Then toVaultPath strips the remote root
+			const vaultPath = toVaultPath(stripped, '/Documents/ObsidianVaults/JeffBrain');
+			expect(vaultPath).toBe('Welcome.md');
+		});
+
+		it('should handle nested file in shared drive end-to-end', () => {
+			const parentPath = '/drives/48043224B16FF524/root:/Documents/ObsidianVaults/JeffBrain/subfolder';
+			const name = 'note.md';
+			const fullPath = `${parentPath}/${name}`;
+			
+			const stripped = stripGraphPrefix(fullPath);
+			const vaultPath = toVaultPath(stripped, '/Documents/ObsidianVaults/JeffBrain');
+			expect(vaultPath).toBe('subfolder/note.md');
+		});
+
+		it('should correctly identify .obsidian files for filtering', () => {
+			const parentPath = '/drives/48043224B16FF524/root:/Documents/ObsidianVaults/JeffBrain/.obsidian';
+			const name = 'workspace.json';
+			const fullPath = `${parentPath}/${name}`;
+			
+			const stripped = stripGraphPrefix(fullPath);
+			const vaultPath = toVaultPath(stripped, '/Documents/ObsidianVaults/JeffBrain');
+			expect(vaultPath).toBe('.obsidian/workspace.json');
+			expect(vaultPath.startsWith('.obsidian/')).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes 6 bugs and adds shared OneDrive folder support with a navigable folder picker UI.

### Bug Fixes
- **Auth scopes**: DeviceCodeFlowClient is now recreated when access mode changes
- **Post-auth sync**: Event listeners start after first-time authentication
- **Token polling leak**: Orphaned polling loop cancelled on successful auth
- **Request error handling**: `requestUrl` uses `throw: false` to properly parse 400 responses
- **Path encoding**: `encodePathForGraph()` encodes segments individually (preserves slashes)
- **Shared folder paths**: `resolveSharedFolderPath()` correctly strips Graph API prefixes

### New Features
- **Shared folder support**: Sync to/from folders shared by other OneDrive users
- **Folder picker**: Navigable folder browser modal in settings with breadcrumb navigation
- **Progress UX**: Single updating notice instead of per-file spam

### Tests
- 20 new tests (65 total, all passing)
- Covers `encodePathForGraph`, `stripGraphPrefix`, `toVaultPath` with shared drive paths
- End-to-end delta path → prefix strip → vault path pipeline tests
