### PR TITLE
Fix .obsidian delta scope, aggressive reset, debug log mirror, large-delete safety

### DIFF
--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -380,11 +380,18 @@ export class OneDriveClient {
 	 * Get changes since last delta token using OneDrive delta API.
 	 * First call (no deltaLink): returns all items + deltaLink.
 	 * Subsequent calls: returns only changes since the token.
+	 *
+	 * @param deltaLink Stored delta cursor; if undefined the call starts a fresh stream.
+	 * @param remotePath Remote vault root path (Full Access mode only).
+	 * @param subPath Optional path under the vault root to scope the delta to (e.g. ".obsidian").
+	 *                When the scoped folder does not yet exist remotely the call returns an empty
+	 *                result so the first sync can proceed and later create it via upload.
 	 */
-	async getDelta(deltaLink?: string, remotePath?: string): Promise<DeltaResponse> {
-		logger.debug('Getting delta changes', { hasDeltaLink: !!deltaLink, remotePath });
+	async getDelta(deltaLink?: string, remotePath?: string, subPath?: string): Promise<DeltaResponse> {
+		logger.debug('Getting delta changes', { hasDeltaLink: !!deltaLink, remotePath, subPath });
 
 		const allItems: OneDriveItem[] = [];
+		const cleanSubPath = subPath ? subPath.replace(/^\/+|\/+$/g, '') : undefined;
 
 		try {
 			let nextUrl: string;
@@ -393,13 +400,26 @@ export class OneDriveClient {
 				// Use stored delta link for incremental changes
 				nextUrl = deltaLink;
 			} else if (this.isSharedDrive()) {
-				// Shared folder — delta scoped to the remote item
-				nextUrl = `/drives/${this.remoteDriveId}/items/${this.remoteItemId}/delta`;
+				if (cleanSubPath) {
+					const encoded = encodePathForGraph(cleanSubPath);
+					nextUrl = `/drives/${this.remoteDriveId}/items/${this.remoteItemId}:/${encoded}:/delta`;
+				} else {
+					nextUrl = `/drives/${this.remoteDriveId}/items/${this.remoteItemId}/delta`;
+				}
 			} else if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
-				nextUrl = '/me/drive/special/approot/delta';
+				if (cleanSubPath) {
+					const encoded = encodePathForGraph(cleanSubPath);
+					nextUrl = `/me/drive/special/approot:/${encoded}:/delta`;
+				} else {
+					nextUrl = '/me/drive/special/approot/delta';
+				}
 			} else if (remotePath) {
 				const cleanPath = remotePath.replace(/^\//, '');
-				const encoded = encodePathForGraph(cleanPath);
+				const fullPath = cleanSubPath ? `${cleanPath}/${cleanSubPath}` : cleanPath;
+				const encoded = encodePathForGraph(fullPath);
+				nextUrl = `/me/drive/root:/${encoded}:/delta`;
+			} else if (cleanSubPath) {
+				const encoded = encodePathForGraph(cleanSubPath);
 				nextUrl = `/me/drive/root:/${encoded}:/delta`;
 			} else {
 				nextUrl = '/me/drive/root/delta';
@@ -428,11 +448,17 @@ export class OneDriveClient {
 
 			return { items: allItems, deltaLink: '' };
 		} catch (error) {
+			// If the scoped folder does not exist yet, treat as empty so first sync can create it.
+			if (cleanSubPath && !deltaLink && this.isItemNotFoundError(error)) {
+				logger.info(`Delta target '${cleanSubPath}' not found remotely — treating as empty`);
+				return { items: [], deltaLink: '' };
+			}
+
 			// If the delta token is invalid/expired, do a full resync
 			if (deltaLink && error instanceof Error &&
 				(error.message.includes('resyncRequired') || error.message.includes('invalidToken'))) {
 				logger.warn('Delta token expired, performing full resync');
-				return this.getDelta(undefined, remotePath); // Retry without token
+				return this.getDelta(undefined, remotePath, subPath); // Retry without token
 			}
 
 			logger.error('Failed to get delta:', error);
@@ -440,6 +466,17 @@ export class OneDriveClient {
 				`Failed to get delta: ${error instanceof Error ? error.message : 'Unknown error'}`
 			);
 		}
+	}
+
+	private isItemNotFoundError(error: unknown): boolean {
+		if (error instanceof OneDriveError) {
+			if (error.statusCode === 404) return true;
+			if (error.code === 'itemNotFound') return true;
+		}
+		if (error instanceof Error && /itemNotFound|404/i.test(error.message)) {
+			return true;
+		}
+		return false;
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,8 +31,22 @@ import { StatusBarManager, SyncStatus } from './ui/statusBar';
 import { DeviceCodeModal } from './ui/authModal';
 import { FolderSelection } from './ui/folderBrowserModal';
 import { ConflictView, CONFLICT_VIEW_TYPE } from './ui/conflictView';
+import { LargeDeleteWarningModal } from './ui/modals';
+
+import { LargeDeleteWarningInfo, LargeDeleteDecision } from './types';
 
 const SYNC_LOGS_NOTE_PATH = '.obsidian/plugins/obsidian-onedrive/OneDrive Sync Logs.md';
+const LIVE_LOG_HEADER = `> [!warning] OneDrive sync debug log
+> This file is **excluded from sync** — each device keeps its own. If you need to share these logs, copy the text into another note (or move this file out of the vault root).
+
+`;
+
+function liveLogNotePath(date: Date = new Date()): string {
+	const yyyy = date.getFullYear();
+	const mm = String(date.getMonth() + 1).padStart(2, '0');
+	const dd = String(date.getDate()).padStart(2, '0');
+	return `_OneDriveSyncLogs-${yyyy}-${mm}-${dd}.md`;
+}
 
 /**
  * Main plugin class
@@ -78,6 +92,8 @@ export default class OneDriveSyncPlugin extends Plugin {
 		if (vaultPath) {
 			logger.enableFileLogging(vaultPath);
 		}
+		// Mirror logs to a vault-root note when debug logging is on
+		this.applyVaultLogHook();
 
 		// Initialize device code client with appropriate client ID and access mode
 		const clientId = this.settings.useCustomClientId
@@ -277,7 +293,9 @@ export default class OneDriveSyncPlugin extends Plugin {
 				remoteRoot,
 				remoteRootOnDrive,
 				this.conflictQueue,
-				(path) => shouldSyncVaultPath(path, this.settings.syncPluginManifests, this.settings.syncAppSettings)
+				(path) => shouldSyncVaultPath(path, this.settings.syncPluginManifests, this.settings.syncAppSettings),
+				() => this.settings.largeDeleteThreshold ?? 0,
+				(info) => this.handleLargeDeleteWarning(info)
 			);
 
 			// Get user info to display in settings
@@ -756,7 +774,10 @@ ${lines.join('\n')}
 	async resetSyncToken(): Promise<void> {
 		this.syncStateManager.clearDeltaLink();
 		await this.saveSettings();
-		new Notice('Sync token reset. Next sync will re-read from OneDrive.');
+		new Notice(
+			'Sync reset. Delta cursors, file states, and last sync time cleared. ' +
+				'Next sync will re-read from OneDrive and reconcile local files.'
+		);
 	}
 
 	/**
@@ -781,7 +802,76 @@ ${lines.join('\n')}
 
 		// Update logger debug mode if changed
 		logger.setDebugMode(this.settings.enableDebugLogging);
+		this.applyVaultLogHook();
 
 		await this.saveData(this.settings);
+	}
+
+	/**
+	 * Install (or remove) a Logger hook that appends each log line to a
+	 * vault-root daily log file. Files match `_OneDriveSyncLogs-YYYY-MM-DD.md`
+	 * and are explicitly excluded from sync via shouldSyncVaultPath so each
+	 * device keeps its own.
+	 */
+	private applyVaultLogHook(): void {
+		if (!this.settings.enableDebugLogging) {
+			logger.setVaultLogHook(null);
+			return;
+		}
+		const adapter = this.app.vault.adapter;
+		// Serialize writes so concurrent log calls don't interleave or race
+		// on file existence checks.
+		let inFlight: Promise<void> = Promise.resolve();
+		logger.setVaultLogHook((line) => {
+			inFlight = inFlight.then(async () => {
+				try {
+					const path = liveLogNotePath();
+					const exists = await adapter.exists(path);
+					if (!exists) {
+						await adapter.write(path, LIVE_LOG_HEADER + line + '\n');
+					} else {
+						await adapter.append(path, line + '\n');
+					}
+				} catch {
+					// Swallow — never let log mirroring break the plugin.
+				}
+			});
+		});
+	}
+
+	/**
+	 * Show the large-delete warning modal and act on the user's choice.
+	 *
+	 * When the user picks "Disable plugin", we actually disable the plugin
+	 * after the modal closes (so the modal can finish unmounting first).
+	 * Either 'cancel' or 'disable' is returned to the sync engine, which
+	 * treats both as "abort this sync without advancing delta cursors".
+	 */
+	private handleLargeDeleteWarning(
+		info: LargeDeleteWarningInfo
+	): Promise<LargeDeleteDecision> {
+		return new Promise((resolve) => {
+			const modal = new LargeDeleteWarningModal(this.app, info, (decision) => {
+				if (decision === 'disable') {
+					// Defer so the modal closes cleanly before unloading the plugin.
+					setTimeout(() => {
+						try {
+							const plugins = (this.app as unknown as {
+								plugins?: { disablePlugin?: (id: string) => Promise<void> | void };
+							}).plugins;
+							if (plugins?.disablePlugin) {
+								void plugins.disablePlugin(this.manifest.id);
+							}
+						} catch (err) {
+							logger.error(
+								`Failed to disable plugin from large-delete modal: ${(err as Error)?.message || err}`
+							);
+						}
+					}, 0);
+				}
+				resolve(decision);
+			});
+			modal.open();
+		});
 	}
 }

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -18,6 +18,8 @@ import {
 	ConflictInfo,
 	LocalChange,
 	LocalChangeType,
+	LargeDeleteWarningHandler,
+	LargeDeleteDecision,
 } from '../types';
 import { logger } from '../utils/logger';
 import {
@@ -51,7 +53,9 @@ export class SyncEngine {
 		private remoteRoot: string = '',
 		remoteRootOnDrive?: string,
 		private conflictQueue?: ConflictQueue,
-		private shouldSyncPath: (path: string) => boolean = (path) => shouldSyncVaultPath(path)
+		private shouldSyncPath: (path: string) => boolean = (path) => shouldSyncVaultPath(path),
+		private getLargeDeleteThreshold: () => number = () => 0,
+		private largeDeleteWarningHandler?: LargeDeleteWarningHandler
 	) {
 		this.isSharedDrive = oneDriveClient.isSharedDrive();
 		// For shared drives, delta items have paths relative to the remote drive root,
@@ -93,13 +97,18 @@ export class SyncEngine {
 
 			// 2. Get remote changes via delta API
 			const deltaLink = this.stateManager.getDeltaLink();
-			const shouldSyncObsidianScope = this.shouldSyncPath('.obsidian/community-plugins.json');
+			// The .obsidian stream is needed if EITHER app-settings or plugin-manifest
+			// sync is enabled. Probe both representative paths so the gate doesn't
+			// silently miss the syncAppSettings-only case.
+			const shouldSyncObsidianScope =
+				this.shouldSyncPath('.obsidian/community-plugins.json') ||
+				this.shouldSyncPath('.obsidian/app.json');
 			const isFirstSync = this.stateManager.isFirstSync();
 			logger.info(`Delta query: isFirstSync=${isFirstSync}, hasDeltaLink=${!!deltaLink}`);
 			const deltaResponse = await this.oneDriveClient.getDelta(deltaLink, this.remoteRoot);
 			const obsidianDeltaLink = this.stateManager.getObsidianDeltaLink();
 			const obsidianDeltaResponse = shouldSyncObsidianScope
-				? await this.oneDriveClient.getDelta(obsidianDeltaLink, this.remoteRoot)
+				? await this.oneDriveClient.getDelta(obsidianDeltaLink, this.remoteRoot, '.obsidian')
 				: undefined;
 
 			// Log all raw delta items for debugging
@@ -149,6 +158,25 @@ export class SyncEngine {
 			logger.info(`Sync plan: ${operations.length} operations`);
 			for (const op of operations) {
 				logger.info(`  Op: ${op.direction} ${op.path}`);
+			}
+
+			// Circuit breaker: if a sync would delete a large number of files,
+			// pause and confirm with the user before proceeding. First syncs are
+			// exempt (the reconciliation logic there doesn't issue deletes).
+			if (!isFirstSync) {
+				const decision = await this.maybeWarnLargeDeletes(operations);
+				if (decision === 'cancel' || decision === 'disable') {
+					logger.warn(
+						`Sync aborted by user (${decision}) due to large delete count. ` +
+							`Delta cursors not advanced; the same plan will be re-evaluated next sync.`
+					);
+					new Notice(
+						decision === 'disable'
+							? 'OneDrive sync: disabled. Investigate the deletes, then re-enable the plugin.'
+							: 'OneDrive sync: cancelled. The pending deletes were not applied.'
+					);
+					return;
+				}
 			}
 
 			if (operations.length === 0) {
@@ -229,6 +257,65 @@ export class SyncEngine {
 			logger.error(`Sync failed: ${errorMsg}`, error);
 			new Notice(`OneDrive sync failed: ${errorMsg}`);
 			throw error;
+		}
+	}
+
+	/**
+	 * Classify operations and, if the planned deletes exceed the configured
+	 * threshold, ask the user (via the injected handler) whether to proceed.
+	 *
+	 * Returns:
+	 *   - 'proceed': run the sync as planned (default when no handler, no
+	 *                threshold, or counts under the threshold).
+	 *   - 'cancel':  abort this sync, do not advance delta cursors so the same
+	 *                pending operations are re-planned next sync.
+	 *   - 'disable': same as cancel; caller has also been asked to disable the
+	 *                plugin via the handler.
+	 */
+	private async maybeWarnLargeDeletes(
+		operations: SyncOperation[]
+	): Promise<LargeDeleteDecision> {
+		const threshold = Math.max(0, Math.floor(this.getLargeDeleteThreshold() || 0));
+		if (threshold <= 0 || !this.largeDeleteWarningHandler) return 'proceed';
+
+		const localDeletes: string[] = []; // remote-driven local deletes (data-loss risk)
+		const remoteDeletes: string[] = []; // local-driven remote deletes
+		for (const op of operations) {
+			if (
+				op.direction === SyncDirection.DOWNLOAD &&
+				op.remoteState === undefined
+			) {
+				localDeletes.push(op.path);
+			} else if (
+				op.direction === SyncDirection.UPLOAD &&
+				op.localState === undefined &&
+				op.remoteState !== undefined
+			) {
+				remoteDeletes.push(op.path);
+			}
+		}
+
+		const total = localDeletes.length + remoteDeletes.length;
+		if (total < threshold) return 'proceed';
+
+		logger.warn(
+			`Large delete detected: ${localDeletes.length} local + ${remoteDeletes.length} remote ` +
+				`(threshold ${threshold}). Asking user before proceeding.`
+		);
+
+		try {
+			return await this.largeDeleteWarningHandler({
+				localDeleteCount: localDeletes.length,
+				remoteDeleteCount: remoteDeletes.length,
+				threshold,
+				sampleLocalDeletes: localDeletes.slice(0, 10),
+				sampleRemoteDeletes: remoteDeletes.slice(0, 10),
+			});
+		} catch (err) {
+			logger.error(
+				`Large-delete warning handler threw; cancelling sync as a safety default: ${(err as Error)?.message || err}`
+			);
+			return 'cancel';
 		}
 	}
 

--- a/src/sync/syncState.ts
+++ b/src/sync/syncState.ts
@@ -146,11 +146,20 @@ export class SyncStateManager {
 	}
 
 	/**
-	 * Clear only the delta link, forcing a full re-read from server on next sync
+	 * Reset for a full re-scan. Clears delta cursors (main + .obsidian),
+	 * fileStates and lastSyncTime so the next sync re-reads everything from
+	 * server and recomputes local↔remote correspondences from scratch.
+	 *
+	 * Note: cleared state means etag/hash checks will not short-circuit, so
+	 * size-match heuristics in the first-sync planner will be used to avoid
+	 * unnecessary re-downloads.
 	 */
 	clearDeltaLink(): void {
-		this.state.deltaLink = undefined;
-		logger.debug('Delta link cleared — next sync will re-read from server');
+		this.state = {
+			lastSyncTime: 0,
+			fileStates: new Map(),
+		};
+		logger.debug('Sync reset — cleared delta links, file states, and last sync time');
 	}
 
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,20 @@ export interface SyncOperation {
 	remoteState?: FileState;
 }
 
+export interface LargeDeleteWarningInfo {
+	localDeleteCount: number; // files about to be deleted from the local vault (driven by remote)
+	remoteDeleteCount: number; // files about to be deleted from OneDrive (driven by local)
+	threshold: number;
+	sampleLocalDeletes: string[]; // up to 10 example paths
+	sampleRemoteDeletes: string[]; // up to 10 example paths
+}
+
+export type LargeDeleteDecision = 'proceed' | 'cancel' | 'disable';
+
+export type LargeDeleteWarningHandler = (
+	info: LargeDeleteWarningInfo
+) => Promise<LargeDeleteDecision>;
+
 export enum ConflictResolutionStrategy {
 	LAST_WRITE_WINS = 'last-write-wins',
 	CREATE_DUPLICATE = 'create-duplicate',
@@ -217,6 +231,7 @@ export interface PluginSettings {
 	remoteRootName?: string; // Display name of the root folder on the remote drive
 	remoteRootPath?: string; // Full path of the folder on the remote drive (e.g. /Documents/ObsidianVaults/JeffBrain)
 	enableDebugLogging: boolean;
+	largeDeleteThreshold: number; // Warn if a sync would delete more than this many files (0 = disabled)
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
@@ -241,6 +256,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
 	// Advanced
 	remotePath: undefined, // Only used with Full Access mode
 	enableDebugLogging: false,
+	largeDeleteThreshold: 25,
 };
 
 // ============================================================================

--- a/src/ui/modals.ts
+++ b/src/ui/modals.ts
@@ -3,7 +3,7 @@
  */
 
 import { Modal, App, Setting } from 'obsidian';
-import { ConflictInfo } from '../types';
+import { ConflictInfo, LargeDeleteWarningInfo, LargeDeleteDecision } from '../types';
 
 /**
  * Conflict resolution modal
@@ -209,5 +209,110 @@ export class ErrorModal extends Modal {
 	onClose() {
 		const { contentEl } = this;
 		contentEl.empty();
+	}
+}
+
+
+/**
+ * Large-delete warning modal
+ *
+ * Shown when a planned sync would delete more files than the configured
+ * threshold. Gives the user three choices: proceed with the sync, cancel
+ * this sync, or cancel and disable the plugin so they can investigate.
+ *
+ * The modal returns the user's decision via a Promise; closing without
+ * picking a button resolves to "cancel" (the safe default).
+ */
+export class LargeDeleteWarningModal extends Modal {
+	private info: LargeDeleteWarningInfo;
+	private resolveDecision: (decision: LargeDeleteDecision) => void;
+	private decision: LargeDeleteDecision = 'cancel';
+
+	constructor(
+		app: App,
+		info: LargeDeleteWarningInfo,
+		resolve: (decision: LargeDeleteDecision) => void
+	) {
+		super(app);
+		this.info = info;
+		this.resolveDecision = resolve;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('onedrive-large-delete-modal');
+
+		contentEl.createEl('h2', { text: 'OneDrive sync: large delete detected' });
+
+		const total = this.info.localDeleteCount + this.info.remoteDeleteCount;
+		const summary = contentEl.createEl('p');
+		summary.setText(
+			`This sync would delete ${total} file${total === 1 ? '' : 's'} ` +
+				`(threshold: ${this.info.threshold}). Review before continuing — ` +
+				`this could indicate an unintended remote change or an accidental local delete.`
+		);
+
+		if (this.info.localDeleteCount > 0) {
+			contentEl.createEl('h3', {
+				text: `${this.info.localDeleteCount} file${this.info.localDeleteCount === 1 ? '' : 's'} would be removed from this vault (driven by remote changes)`,
+			});
+			this.renderSamples(contentEl, this.info.sampleLocalDeletes, this.info.localDeleteCount);
+		}
+
+		if (this.info.remoteDeleteCount > 0) {
+			contentEl.createEl('h3', {
+				text: `${this.info.remoteDeleteCount} file${this.info.remoteDeleteCount === 1 ? '' : 's'} would be removed from OneDrive (driven by local deletes)`,
+			});
+			this.renderSamples(
+				contentEl,
+				this.info.sampleRemoteDeletes,
+				this.info.remoteDeleteCount
+			);
+		}
+
+		const hint = contentEl.createEl('p');
+		hint.setText(
+			'If you cancel or disable, the delta cursor is preserved so the same ' +
+				'plan will be re-checked next sync. Nothing has been deleted yet.'
+		);
+
+		new Setting(contentEl)
+			.addButton((b) =>
+				b
+					.setButtonText('Cancel sync')
+					.setCta()
+					.onClick(() => {
+						this.decision = 'cancel';
+						this.close();
+					})
+			)
+			.addButton((b) =>
+				b.setButtonText('Disable plugin').onClick(() => {
+					this.decision = 'disable';
+					this.close();
+				})
+			)
+			.addButton((b) =>
+				b.setButtonText('Proceed (this sync only)').setWarning().onClick(() => {
+					this.decision = 'proceed';
+					this.close();
+				})
+			);
+	}
+
+	private renderSamples(parent: HTMLElement, samples: string[], total: number) {
+		const list = parent.createEl('ul');
+		for (const path of samples) {
+			list.createEl('li', { text: path });
+		}
+		if (total > samples.length) {
+			parent.createEl('p', { text: `… and ${total - samples.length} more.` });
+		}
+	}
+
+	onClose() {
+		this.contentEl.empty();
+		this.resolveDecision(this.decision);
 	}
 }

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -331,6 +331,26 @@ export class OneDriveSettingTab extends PluginSettingTab {
 				})
 			);
 
+		// Large-delete safety threshold
+		new Setting(containerEl)
+			.setName('Large delete warning threshold')
+			.setDesc(
+				'Pause and ask before a sync that would delete this many files. ' +
+					'Helps catch unintended remote deletions or accidental local deletes. ' +
+					'Set to 0 to disable.'
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder('25')
+					.setValue(String(this.plugin.settings.largeDeleteThreshold ?? 25))
+					.onChange(async (value) => {
+						const parsed = parseInt(value, 10);
+						if (Number.isNaN(parsed) || parsed < 0) return;
+						this.plugin.settings.largeDeleteThreshold = parsed;
+						await this.plugin.saveSettings();
+					})
+			);
+
 		// Show remote path as read-only text in App Folder mode
 		if (this.plugin.settings.accessMode === OneDriveAccessMode.APP_FOLDER) {
 			new Setting(containerEl)

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -20,11 +20,21 @@ class Logger {
 	private minLevel = LogLevel.INFO;
 	private logFilePath: string | null = null;
 	private recentLogs: string[] = [];
+	private vaultLogHook: ((line: string) => void) | null = null;
 	private static readonly MAX_RECENT_LOGS = 500;
 
 	setDebugMode(enabled: boolean) {
 		this.enableDebug = enabled;
 		this.minLevel = enabled ? LogLevel.DEBUG : LogLevel.INFO;
+	}
+
+	/**
+	 * Register (or clear) a sink that receives every formatted log line.
+	 * Used by the plugin to mirror logs into a vault-root note for in-app /
+	 * mobile inspection. Pass null to detach.
+	 */
+	setVaultLogHook(hook: ((line: string) => void) | null): void {
+		this.vaultLogHook = hook;
 	}
 
 	/**
@@ -74,6 +84,13 @@ class Logger {
 		this.recentLogs.push(line);
 		if (this.recentLogs.length > Logger.MAX_RECENT_LOGS) {
 			this.recentLogs.shift();
+		}
+		if (this.vaultLogHook) {
+			try {
+				this.vaultLogHook(line);
+			} catch {
+				// Never let a sink failure break logging
+			}
 		}
 	}
 

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -158,11 +158,19 @@ function isInstalledPluginBinaryPath(path: string): boolean {
 	return /^\.obsidian\/plugins\/[^/]+\/(main\.js|styles\.css)$/.test(path);
 }
 
+const LOG_NOTE_PATTERN = /^_OneDriveSyncLogs(-\d{4}-\d{2}-\d{2})?\.md$/;
+
 /**
  * Check whether a vault path should be synced.
  */
 export function shouldSyncVaultPath(path: string, syncPluginManifests = false, syncAppSettings = false): boolean {
 	const normalized = normalizePath(path);
+
+	// Plugin debug log files live in the vault root so mobile users can open them
+	// from the file explorer, but they must never sync (each device writes its own).
+	if (LOG_NOTE_PATTERN.test(normalized)) {
+		return false;
+	}
 
 	if (!normalized.startsWith('.obsidian/')) {
 		return true;

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => {
 		error: vi.fn(),
 		setDebugMode: vi.fn(),
 		enableFileLogging: vi.fn(),
+		setVaultLogHook: vi.fn(),
 		getRecentLogs: vi.fn().mockReturnValue([]),
 	};
 

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -8,6 +8,7 @@ vi.mock('../../../src/utils/logger', () => ({
 		error: vi.fn(),
 		setDebugMode: vi.fn(),
 		enableFileLogging: vi.fn(),
+		setVaultLogHook: vi.fn(),
 	},
 }));
 
@@ -611,7 +612,7 @@ describe('SyncEngine', () => {
 		await syncEngine.performSync();
 
 		expect(mockClient.getDelta).toHaveBeenNthCalledWith(1, 'main-delta-old', '/remote/root');
-		expect(mockClient.getDelta).toHaveBeenNthCalledWith(2, 'obsidian-delta-old', '/remote/root');
+		expect(mockClient.getDelta).toHaveBeenNthCalledWith(2, 'obsidian-delta-old', '/remote/root', '.obsidian');
 		expect(stateManager.getDeltaLink()).toBe('main-delta-new');
 		expect(stateManager.getObsidianDeltaLink()).toBe('obsidian-delta-new');
 	});
@@ -626,6 +627,32 @@ describe('SyncEngine', () => {
 		expect(mockClient.getDelta).toHaveBeenCalledTimes(1);
 		expect(stateManager.getDeltaLink()).toBe('main-delta-new');
 		expect(stateManager.getObsidianDeltaLink()).toBe('obsidian-delta-existing');
+	});
+
+	it('runs the .obsidian delta stream when only syncAppSettings is enabled', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		syncEngine = new SyncEngine(
+			mockApp as any,
+			mockFileOps as any,
+			mockClient as any,
+			stateManager,
+			conflictResolver,
+			mockEventManager as any,
+			'/remote/root',
+			undefined,
+			undefined,
+			// syncPluginManifests=false, syncAppSettings=true
+			(path) => shouldSyncVaultPath(path, false, true)
+		);
+		mockClient.getDelta
+			.mockResolvedValueOnce({ items: [], deltaLink: 'main-delta-new' })
+			.mockResolvedValueOnce({ items: [], deltaLink: 'obsidian-delta-new' });
+
+		await syncEngine.performSync();
+
+		expect(mockClient.getDelta).toHaveBeenCalledTimes(2);
+		expect(mockClient.getDelta).toHaveBeenNthCalledWith(2, undefined, '/remote/root', '.obsidian');
+		expect(stateManager.getObsidianDeltaLink()).toBe('obsidian-delta-new');
 	});
 
 	it('filters remote changes using .syncIgnore patterns', async () => {
@@ -699,6 +726,27 @@ describe('SyncEngine', () => {
 		await syncEngine.performSync();
 
 		expect(mockEventManager.clearDirtyFiles).toHaveBeenCalledTimes(1);
+	});
+
+	it('clearDeltaLink resets delta cursors, file states, and lastSyncTime', () => {
+		stateManager.setLastSyncTime(Date.now());
+		stateManager.setDeltaLink('main-delta');
+		stateManager.setObsidianDeltaLink('obsidian-delta');
+		stateManager.setFileState('notes/keep.md', {
+			path: 'notes/keep.md',
+			localMtime: 1,
+			remoteHash: 'abc',
+			size: 10,
+			remoteModifiedTime: 1,
+			oneDriveId: 'id-1',
+		});
+
+		stateManager.clearDeltaLink();
+
+		expect(stateManager.getDeltaLink()).toBeUndefined();
+		expect(stateManager.getObsidianDeltaLink()).toBeUndefined();
+		expect(stateManager.getFileState('notes/keep.md')).toBeUndefined();
+		expect(stateManager.isFirstSync()).toBe(true);
 	});
 
 	it('removes downloaded paths from the dirty set', async () => {
@@ -787,5 +835,153 @@ describe('SyncEngine', () => {
 		}
 
 		await syncPromise;
+	});
+});
+
+
+describe('SyncEngine large-delete circuit breaker', () => {
+	let stateManager: SyncStateManager;
+	let conflictResolver: ConflictResolver;
+	let mockFileOps: any;
+	let mockClient: any;
+	let mockEventManager: any;
+
+	beforeEach(() => {
+		stateManager = new SyncStateManager();
+		conflictResolver = new ConflictResolver(ConflictResolutionStrategy.LAST_WRITE_WINS);
+		mockFileOps = {
+			uploadFile: vi.fn().mockResolvedValue({ id: 'uploaded-id', size: 100 }),
+			downloadFile: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
+			deleteFile: vi.fn().mockResolvedValue(undefined),
+		};
+		mockClient = {
+			getDelta: vi.fn().mockResolvedValue({ items: [], deltaLink: 'delta-link-1' }),
+			isSharedDrive: vi.fn().mockReturnValue(false),
+		};
+		mockEventManager = {
+			getDirtyFiles: vi.fn().mockReturnValue([]),
+			clearDirtyFiles: vi.fn(),
+			addDirtyFile: vi.fn(),
+			removeDirtyPaths: vi.fn(),
+			markOwnWrites: vi.fn(),
+		};
+	});
+
+	function makeEngine(threshold: number, handler?: any) {
+		return new SyncEngine(
+			mockApp as any,
+			mockFileOps,
+			mockClient,
+			stateManager,
+			conflictResolver,
+			mockEventManager,
+			'/remote/root',
+			undefined,
+			undefined,
+			() => true,
+			() => threshold,
+			handler
+		);
+	}
+
+	function seedDeletes(remoteDeleteCount: number) {
+		// Establish state so the engine knows the files existed; not first sync.
+		stateManager.setLastSyncTime(Date.now());
+		stateManager.setDeltaLink('prev-delta');
+		const deletes = Array.from({ length: remoteDeleteCount }, (_, i) =>
+			makeRemoteDelete(`notes/gone-${i}.md`, { id: `gone-${i}-id` })
+		);
+		for (let i = 0; i < remoteDeleteCount; i++) {
+			const path = `notes/gone-${i}.md`;
+			stateManager.setFileState(path, {
+				path,
+				localMtime: 1,
+				remoteHash: 'h',
+				size: 10,
+				remoteModifiedTime: 1,
+				oneDriveId: `gone-${i}-id`,
+			});
+			(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation((p: string) =>
+				p.startsWith('notes/gone-') ? makeTFile(p, 10, Date.now()) : null
+			);
+		}
+		mockClient.getDelta.mockResolvedValue({ items: deletes, deltaLink: 'next-delta' });
+	}
+
+	it('does not warn when delete count is below the threshold', async () => {
+		const handler = vi.fn();
+		const engine = makeEngine(10, handler);
+		seedDeletes(3);
+
+		await engine.performSync();
+
+		expect(handler).not.toHaveBeenCalled();
+		expect(mockApp.vault.delete).toHaveBeenCalled();
+		expect(stateManager.getDeltaLink()).toBe('next-delta');
+	});
+
+	it('does not warn when threshold is 0 (disabled)', async () => {
+		const handler = vi.fn();
+		const engine = makeEngine(0, handler);
+		seedDeletes(50);
+
+		await engine.performSync();
+
+		expect(handler).not.toHaveBeenCalled();
+		expect(mockApp.vault.delete).toHaveBeenCalled();
+	});
+
+	it('asks the handler when delete count meets the threshold and proceeds on "proceed"', async () => {
+		const handler = vi.fn().mockResolvedValue('proceed');
+		const engine = makeEngine(5, handler);
+		seedDeletes(7);
+
+		await engine.performSync();
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		const info = handler.mock.calls[0][0];
+		expect(info.localDeleteCount).toBe(7);
+		expect(info.remoteDeleteCount).toBe(0);
+		expect(info.sampleLocalDeletes).toHaveLength(7);
+		expect(mockApp.vault.delete).toHaveBeenCalledTimes(7);
+		expect(stateManager.getDeltaLink()).toBe('next-delta');
+	});
+
+	it('aborts without advancing the delta cursor when the user cancels', async () => {
+		const handler = vi.fn().mockResolvedValue('cancel');
+		const engine = makeEngine(5, handler);
+		seedDeletes(7);
+
+		await engine.performSync();
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		expect(mockApp.vault.delete).not.toHaveBeenCalled();
+		// Cursor still points at the pre-sync value so the user gets re-prompted next time.
+		expect(stateManager.getDeltaLink()).toBe('prev-delta');
+	});
+
+	it('aborts without advancing the delta cursor when the user picks "disable"', async () => {
+		const handler = vi.fn().mockResolvedValue('disable');
+		const engine = makeEngine(5, handler);
+		seedDeletes(7);
+
+		await engine.performSync();
+
+		expect(mockApp.vault.delete).not.toHaveBeenCalled();
+		expect(stateManager.getDeltaLink()).toBe('prev-delta');
+	});
+
+	it('skips the warning on first sync even when many files would be touched', async () => {
+		const handler = vi.fn();
+		const engine = makeEngine(5, handler);
+		// First sync: no prior deltaLink, no prior lastSyncTime.
+		const deletes = Array.from({ length: 10 }, (_, i) =>
+			makeRemoteDelete(`notes/gone-${i}.md`, { id: `gone-${i}-id` })
+		);
+		mockClient.getDelta.mockResolvedValue({ items: deletes, deltaLink: 'first-delta' });
+
+		await engine.performSync();
+
+		expect(handler).not.toHaveBeenCalled();
 	});
 });

--- a/tests/unit/utils/pathUtils.test.ts
+++ b/tests/unit/utils/pathUtils.test.ts
@@ -309,5 +309,14 @@ describe('pathUtils', () => {
 			expect(shouldSyncVaultPath('.obsidian/workspace.json', true, true)).toBe(false);
 			expect(shouldSyncVaultPath('.obsidian/plugins/calendar/data.json', true, true)).toBe(false);
 		});
+
+		it('always excludes the per-device debug log notes from sync', () => {
+			expect(shouldSyncVaultPath('_OneDriveSyncLogs.md')).toBe(false);
+			expect(shouldSyncVaultPath('_OneDriveSyncLogs-2026-06-04.md')).toBe(false);
+			expect(shouldSyncVaultPath('_OneDriveSyncLogs-2026-06-04.md', true, true)).toBe(false);
+			// Adjacent paths that aren't log files should still sync
+			expect(shouldSyncVaultPath('_OneDriveSyncLogs/foo.md')).toBe(true);
+			expect(shouldSyncVaultPath('notes/_OneDriveSyncLogs.md')).toBe(true);
+		});
 	});
 });


### PR DESCRIPTION
## What

- **Scoped .obsidian delta** — second delta call now targets the .obsidian subtree (:/<path>:/delta) across app-folder, full-access, and shared-drive modes. Handles first-sync 404 gracefully.
- **Broadened gate** — .obsidian stream now runs when *either* syncAppSettings or syncPluginManifests is enabled (previously syncAppSettings-only would skip it).
- **Aggressive Reset Sync Token** — clears both delta cursors, file states, and lastSyncTime so a reset truly starts over.
- **Per-device debug log mirror** — when debug logging is enabled, log lines also append to `_OneDriveSyncLogs-YYYY-MM-DD.md` in the vault root. File is excluded from sync. Lets mobile users inspect logs.
- **Large-delete circuit breaker** — if a sync would delete more files than the configured threshold (default 25, 0 = disabled), pop a modal: *Cancel sync / Disable plugin / Proceed*. Cancel and Disable do NOT advance delta cursors, so the same plan is re-evaluated on the next sync. First syncs are exempt.

## Tests

202 passing (6 new):
- 1 syncEngine reset test
- 1 syncEngine .obsidian-gate test (syncAppSettings-only)
- 1 pathUtils log-file exclusion test
- 6 syncEngine large-delete circuit breaker tests

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>