### PR TITLE
First-sync local vault enumeration + log folder consolidation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,8 +36,9 @@ import { LargeDeleteWarningModal } from './ui/modals';
 import { LargeDeleteWarningInfo, LargeDeleteDecision } from './types';
 
 const SYNC_LOGS_NOTE_PATH = '.obsidian/plugins/obsidian-onedrive/OneDrive Sync Logs.md';
+const LIVE_LOG_FOLDER = '_OneDriveSyncLogs';
 const LIVE_LOG_HEADER = `> [!warning] OneDrive sync debug log
-> This file is **excluded from sync** — each device keeps its own. If you need to share these logs, copy the text into another note (or move this file out of the vault root).
+> This folder is **excluded from sync** — each device keeps its own. To share a specific day's log, move that file out of this folder.
 
 `;
 
@@ -45,7 +46,7 @@ function liveLogNotePath(date: Date = new Date()): string {
 	const yyyy = date.getFullYear();
 	const mm = String(date.getMonth() + 1).padStart(2, '0');
 	const dd = String(date.getDate()).padStart(2, '0');
-	return `_OneDriveSyncLogs-${yyyy}-${mm}-${dd}.md`;
+	return `${LIVE_LOG_FOLDER}/${yyyy}-${mm}-${dd}.md`;
 }
 
 /**
@@ -828,6 +829,10 @@ ${lines.join('\n')}
 					const path = liveLogNotePath();
 					const exists = await adapter.exists(path);
 					if (!exists) {
+						const folderExists = await adapter.exists(LIVE_LOG_FOLDER);
+						if (!folderExists) {
+							await adapter.mkdir(LIVE_LOG_FOLDER);
+						}
 						await adapter.write(path, LIVE_LOG_HEADER + line + '\n');
 					} else {
 						await adapter.append(path, line + '\n');

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -155,6 +155,34 @@ export class SyncEngine {
 			// 3. Plan operations
 			const operations = this.planOperations(localChanges, remoteChanges, isFirstSync);
 
+			// 3b. On first sync (or post-reset), the dirty-file queue is empty so
+			// the planner only sees files via the remote delta. Local files that
+			// don't exist remotely would silently be skipped. Walk the vault here
+			// and add UPLOAD ops for any syncable local-only files.
+			if (isFirstSync) {
+				const remoteCoveredPaths = new Set<string>(operations.map((op) => op.path));
+				// Any file whose state was stored during planOperations (same-size
+				// short-circuit) is also "covered" — local matches remote, no work.
+				for (const path of this.stateManager.getTrackedPaths()) {
+					remoteCoveredPaths.add(path);
+				}
+				let localOnlyCount = 0;
+				for (const file of this.app.vault.getFiles()) {
+					const path = file.path;
+					if (remoteCoveredPaths.has(path)) continue;
+					if (!this.shouldSyncPath(path)) continue;
+					if (this.shouldIgnorePath(path, ignoreMatchers)) continue;
+					if (this.conflictQueue?.hasConflict(path)) continue;
+					operations.push({ path, direction: SyncDirection.UPLOAD });
+					localOnlyCount++;
+				}
+				if (localOnlyCount > 0) {
+					logger.info(
+						`First-sync local enumeration: queued ${localOnlyCount} local-only file uploads`
+					);
+				}
+			}
+
 			logger.info(`Sync plan: ${operations.length} operations`);
 			for (const op of operations) {
 				logger.info(`  Op: ${op.direction} ${op.path}`);

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -158,7 +158,7 @@ function isInstalledPluginBinaryPath(path: string): boolean {
 	return /^\.obsidian\/plugins\/[^/]+\/(main\.js|styles\.css)$/.test(path);
 }
 
-const LOG_NOTE_PATTERN = /^_OneDriveSyncLogs(-\d{4}-\d{2}-\d{2})?\.md$/;
+const LOG_NOTE_FOLDER = '_OneDriveSyncLogs/';
 
 /**
  * Check whether a vault path should be synced.
@@ -166,9 +166,10 @@ const LOG_NOTE_PATTERN = /^_OneDriveSyncLogs(-\d{4}-\d{2}-\d{2})?\.md$/;
 export function shouldSyncVaultPath(path: string, syncPluginManifests = false, syncAppSettings = false): boolean {
 	const normalized = normalizePath(path);
 
-	// Plugin debug log files live in the vault root so mobile users can open them
-	// from the file explorer, but they must never sync (each device writes its own).
-	if (LOG_NOTE_PATTERN.test(normalized)) {
+	// Plugin debug log notes live in a dedicated folder so each device keeps its
+	// own. The leading underscore is on the folder, so users who want to share a
+	// specific day's log can simply move that file out of the folder.
+	if (normalized === LOG_NOTE_FOLDER.slice(0, -1) || normalized.startsWith(LOG_NOTE_FOLDER)) {
 		return false;
 	}
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -26,7 +26,7 @@ export const mockApp = {
 		off: vi.fn(),
 		offref: vi.fn(),
 		getAbstractFileByPath: vi.fn(),
-		getFiles: vi.fn(),
+		getFiles: vi.fn().mockReturnValue([]),
 		readBinary: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
 		delete: vi.fn().mockResolvedValue(undefined),
 	},

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -985,3 +985,114 @@ describe('SyncEngine large-delete circuit breaker', () => {
 		expect(handler).not.toHaveBeenCalled();
 	});
 });
+
+
+describe('SyncEngine first-sync local vault enumeration', () => {
+	let stateManager: SyncStateManager;
+	let conflictResolver: ConflictResolver;
+	let mockFileOps: any;
+	let mockClient: any;
+	let mockEventManager: any;
+
+	beforeEach(() => {
+		stateManager = new SyncStateManager();
+		conflictResolver = new ConflictResolver(ConflictResolutionStrategy.LAST_WRITE_WINS);
+		mockFileOps = {
+			uploadFile: vi.fn().mockResolvedValue({ id: 'uploaded-id', size: 100 }),
+			downloadFile: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
+			deleteFile: vi.fn().mockResolvedValue(undefined),
+		};
+		mockClient = {
+			getDelta: vi.fn().mockResolvedValue({ items: [], deltaLink: 'first-delta' }),
+			isSharedDrive: vi.fn().mockReturnValue(false),
+		};
+		mockEventManager = {
+			getDirtyFiles: vi.fn().mockReturnValue([]),
+			clearDirtyFiles: vi.fn(),
+			addDirtyFile: vi.fn(),
+			removeDirtyPaths: vi.fn(),
+			markOwnWrites: vi.fn(),
+		};
+	});
+
+	function makeEngine() {
+		return new SyncEngine(
+			mockApp as any,
+			mockFileOps,
+			mockClient,
+			stateManager,
+			conflictResolver,
+			mockEventManager,
+			'/remote/root'
+		);
+	}
+
+	it('uploads local-only files on first sync even when the dirty queue is empty', async () => {
+		// Phone has notes that OneDrive has never seen — empty remote delta.
+		const localFiles = [
+			makeTFile('notes/keep.md', 10, Date.now()),
+			makeTFile('Home/idea.md', 20, Date.now()),
+		];
+		(mockApp.vault.getFiles as Mock).mockReturnValue(localFiles);
+		(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation(
+			(p: string) => localFiles.find((f) => f.path === p) ?? null
+		);
+
+		await makeEngine().performSync();
+
+		const uploadedPaths = mockFileOps.uploadFile.mock.calls.map((c: any[]) => c[0]).sort();
+		expect(uploadedPaths).toEqual(['/remote/root/Home/idea.md', '/remote/root/notes/keep.md']);
+	});
+
+	it('does not duplicate uploads for files already matched by remote on first sync', async () => {
+		const localFiles = [
+			makeTFile('notes/keep.md', 100, Date.now()), // same size as remote — should size-match
+			makeTFile('notes/local-only.md', 50, Date.now()),
+		];
+		(mockApp.vault.getFiles as Mock).mockReturnValue(localFiles);
+		(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation(
+			(p: string) => localFiles.find((f) => f.path === p) ?? null
+		);
+		mockClient.getDelta.mockResolvedValue({
+			items: [makeRemoteFile('notes/keep.md', { id: 'remote-keep', size: 100 })],
+			deltaLink: 'first-delta',
+		});
+
+		await makeEngine().performSync();
+
+		const uploadedPaths = mockFileOps.uploadFile.mock.calls.map((c: any[]) => c[0]);
+		expect(uploadedPaths).toEqual(['/remote/root/notes/local-only.md']);
+	});
+
+	it('skips local files that should not be synced (e.g. the log folder)', async () => {
+		const localFiles = [
+			makeTFile('notes/keep.md', 10, Date.now()),
+			makeTFile('_OneDriveSyncLogs/2026-06-04.md', 999, Date.now()),
+		];
+		(mockApp.vault.getFiles as Mock).mockReturnValue(localFiles);
+		(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation(
+			(p: string) => localFiles.find((f) => f.path === p) ?? null
+		);
+
+		await makeEngine().performSync();
+
+		const uploadedPaths = mockFileOps.uploadFile.mock.calls.map((c: any[]) => c[0]);
+		expect(uploadedPaths).toEqual(['/remote/root/notes/keep.md']);
+	});
+
+	it('does not enumerate local files on subsequent (non-first) syncs', async () => {
+		// Establish prior sync state so isFirstSync() is false.
+		stateManager.setLastSyncTime(Date.now());
+		stateManager.setDeltaLink('prev-delta');
+		const localFiles = [makeTFile('notes/local-only.md', 50, Date.now())];
+		(mockApp.vault.getFiles as Mock).mockReturnValue(localFiles);
+		(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation(
+			(p: string) => localFiles.find((f) => f.path === p) ?? null
+		);
+
+		await makeEngine().performSync();
+
+		// Without an event-driven dirty entry, a non-first sync should NOT upload.
+		expect(mockFileOps.uploadFile).not.toHaveBeenCalled();
+	});
+});

--- a/tests/unit/utils/pathUtils.test.ts
+++ b/tests/unit/utils/pathUtils.test.ts
@@ -310,13 +310,16 @@ describe('pathUtils', () => {
 			expect(shouldSyncVaultPath('.obsidian/plugins/calendar/data.json', true, true)).toBe(false);
 		});
 
-		it('always excludes the per-device debug log notes from sync', () => {
-			expect(shouldSyncVaultPath('_OneDriveSyncLogs.md')).toBe(false);
-			expect(shouldSyncVaultPath('_OneDriveSyncLogs-2026-06-04.md')).toBe(false);
-			expect(shouldSyncVaultPath('_OneDriveSyncLogs-2026-06-04.md', true, true)).toBe(false);
-			// Adjacent paths that aren't log files should still sync
-			expect(shouldSyncVaultPath('_OneDriveSyncLogs/foo.md')).toBe(true);
-			expect(shouldSyncVaultPath('notes/_OneDriveSyncLogs.md')).toBe(true);
+		it('always excludes the per-device debug log folder from sync', () => {
+			expect(shouldSyncVaultPath('_OneDriveSyncLogs')).toBe(false);
+			expect(shouldSyncVaultPath('_OneDriveSyncLogs/2026-06-04.md')).toBe(false);
+			expect(shouldSyncVaultPath('_OneDriveSyncLogs/sub/dir/note.md', true, true)).toBe(false);
+			// Files that just look similar should still sync — exclusion is
+			// folder-scoped, not name-scoped, so moving a log out of the folder
+			// makes it syncable again.
+			expect(shouldSyncVaultPath('_OneDriveSyncLogs-2026-06-04.md')).toBe(true);
+			expect(shouldSyncVaultPath('_OneDriveSyncLogsBackup/foo.md')).toBe(true);
+			expect(shouldSyncVaultPath('notes/_OneDriveSyncLogs/x.md')).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
## What

### First-sync local vault enumeration (the real fix)

The sync engine only knew about local files via the event-driven dirty queue. After `Reset Sync Token` (or a fresh install), that queue is empty, so local files that didn't exist remotely were silently ignored. Symptom: 'I reset, but my local-only files never upload.'

Now, on first sync only, after planOperations the engine walks `app.vault.getFiles()` and queues UPLOAD ops for any syncable file that wasn't already covered by the remote delta or matched into stateManager. Regular incremental syncs are unchanged (still event-driven).

### Debug log folder

Logs now live in `_OneDriveSyncLogs/<YYYY-MM-DD>.md`. The folder carries the underscore so the whole folder is excluded from sync — but individual files have plain date names. To share a specific day's log, just move it out of the folder.

shouldSyncVaultPath was switched from a filename regex to a folder-prefix exclusion.

## Tests

206 passing (4 new for first-sync enumeration, log folder test updated for new scheme).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>