### PR TITLE
Sync progress visibility + exclude self-sync and workspace churn

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -296,7 +296,8 @@ export default class OneDriveSyncPlugin extends Plugin {
 				this.conflictQueue,
 				(path) => shouldSyncVaultPath(path, this.settings.syncPluginManifests, this.settings.syncAppSettings),
 				() => this.settings.largeDeleteThreshold ?? 0,
-				(info) => this.handleLargeDeleteWarning(info)
+				(info) => this.handleLargeDeleteWarning(info),
+				(msg) => this.statusBarManager?.setProgress(msg)
 			);
 
 			// Get user info to display in settings

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -55,7 +55,8 @@ export class SyncEngine {
 		private conflictQueue?: ConflictQueue,
 		private shouldSyncPath: (path: string) => boolean = (path) => shouldSyncVaultPath(path),
 		private getLargeDeleteThreshold: () => number = () => 0,
-		private largeDeleteWarningHandler?: LargeDeleteWarningHandler
+		private largeDeleteWarningHandler?: LargeDeleteWarningHandler,
+		private onProgress?: (message: string | undefined) => void
 	) {
 		this.isSharedDrive = oneDriveClient.isSharedDrive();
 		// For shared drives, delta items have paths relative to the remote drive root,
@@ -72,8 +73,16 @@ export class SyncEngine {
 	 */
 	async performSync(): Promise<void> {
 		logger.info('Starting sync operation');
+		const progress = (msg: string | undefined) => {
+			try {
+				this.onProgress?.(msg);
+			} catch {
+				// progress reporting must never break sync
+			}
+		};
 
 		try {
+			progress('starting...');
 			// 1. Get local changes from event manager
 			const ignoreMatchers = await this.loadIgnoreMatchers();
 			const allLocalChanges = this.eventManager.getDirtyFiles();
@@ -96,6 +105,7 @@ export class SyncEngine {
 			}
 
 			// 2. Get remote changes via delta API
+			progress('fetching remote changes...');
 			const deltaLink = this.stateManager.getDeltaLink();
 			// The .obsidian stream is needed if EITHER app-settings or plugin-manifest
 			// sync is enabled. Probe both representative paths so the gate doesn't
@@ -107,9 +117,14 @@ export class SyncEngine {
 			logger.info(`Delta query: isFirstSync=${isFirstSync}, hasDeltaLink=${!!deltaLink}`);
 			const deltaResponse = await this.oneDriveClient.getDelta(deltaLink, this.remoteRoot);
 			const obsidianDeltaLink = this.stateManager.getObsidianDeltaLink();
+			if (shouldSyncObsidianScope) {
+				progress('fetching .obsidian changes...');
+			}
 			const obsidianDeltaResponse = shouldSyncObsidianScope
 				? await this.oneDriveClient.getDelta(obsidianDeltaLink, this.remoteRoot, '.obsidian')
 				: undefined;
+
+			progress('planning...');
 
 			// Log all raw delta items for debugging
 			for (const item of deltaResponse.items) {
@@ -229,6 +244,7 @@ export class SyncEngine {
 			let completed = 0;
 			const downloadedPaths: string[] = [];
 			const conflictedPaths: string[] = [];
+			progress(`0/${operations.length} files`);
 			// Single persistent notice for progress — updates in place
 			const progressNotice =
 				operations.length >= 5 ? new Notice(`Syncing: 0/${operations.length} files...`, 0) : null;
@@ -242,12 +258,15 @@ export class SyncEngine {
 					conflictedPaths.push(operation.path);
 				}
 
+				const progressLabel = `${completed}/${operations.length} files`;
+				progress(progressLabel);
 				if (progressNotice) {
-					progressNotice.setMessage(`Syncing: ${completed}/${operations.length} files...`);
+					progressNotice.setMessage(`Syncing: ${progressLabel}...`);
 				}
 			});
 			// Dismiss progress notice
 			progressNotice?.hide();
+			progress(undefined);
 
 			// Clear any dirty-file entries for paths we just downloaded,
 			// so they don't boomerang back as uploads on the next cycle

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -83,6 +83,24 @@ export class SyncEngine {
 
 		try {
 			progress('starting...');
+
+			// Inventory snapshot — surfaces drift between what the plugin thinks
+			// is synced (tracked state) and what's actually in the vault. A large
+			// gap is the fingerprint of silent delete drops (e.g. Graph delta
+			// collapse hiding deletes that happened on another device).
+			const trackedCount = this.stateManager.getTrackedPaths().length;
+			const vaultCount = this.app.vault.getFiles().length;
+			const drift = vaultCount - trackedCount;
+			logger.info(
+				`Inventory: vaultFiles=${vaultCount} trackedStates=${trackedCount} drift=${drift >= 0 ? '+' : ''}${drift}`
+			);
+			if (Math.abs(drift) > 10 && trackedCount > 0) {
+				logger.warn(
+					`Inventory drift detected: vault has ${vaultCount} files but plugin tracks ${trackedCount} (${drift >= 0 ? '+' : ''}${drift}). ` +
+						`If the local total is much higher, this device may hold files that were deleted on another device but the delta API never reported the deletion.`
+				);
+			}
+
 			// 1. Get local changes from event manager
 			const ignoreMatchers = await this.loadIgnoreMatchers();
 			const allLocalChanges = this.eventManager.getDirtyFiles();
@@ -157,8 +175,16 @@ export class SyncEngine {
 				}) || []),
 			];
 
+			const obsidianRawCount = obsidianDeltaResponse?.items.length || 0;
+			const mainDeletes = deltaResponse.items.filter((i) => i.deleted).length;
+			const mainFolders = deltaResponse.items.filter((i) => !!i.folder).length;
+			const obsidianDeletes = obsidianDeltaResponse?.items.filter((i) => i.deleted).length || 0;
+			const remoteDeletes = remoteChanges.filter((i) => i.deleted).length;
 			logger.info(
-				`Delta returned ${deltaResponse.items.length} total items, ${remoteChanges.length} file changes`
+				`Delta returned ${deltaResponse.items.length + obsidianRawCount} raw items ` +
+					`(main: total=${deltaResponse.items.length} deletes=${mainDeletes} folders=${mainFolders}; ` +
+					`obsidian: total=${obsidianRawCount} deletes=${obsidianDeletes}); ` +
+					`${remoteChanges.length} kept after filter (${remoteDeletes} deletes)`
 			);
 			for (const item of remoteChanges) {
 				const vaultPath = this.remotePathToVaultPath(item);

--- a/src/ui/statusBar.ts
+++ b/src/ui/statusBar.ts
@@ -20,6 +20,7 @@ export class StatusBarManager {
 	private currentStatus: SyncStatus = SyncStatus.DISCONNECTED;
 	private lastSyncTime?: number;
 	private conflictCount = 0;
+	private progressMessage?: string;
 
 	constructor(statusBarItem: HTMLElement, private onSyncClick?: () => void) {
 		this.statusBarItem = statusBarItem;
@@ -38,8 +39,22 @@ export class StatusBarManager {
 	 */
 	setStatus(status: SyncStatus): void {
 		this.currentStatus = status;
+		if (status !== SyncStatus.SYNCING) {
+			this.progressMessage = undefined;
+		}
 		this.updateDisplay();
 		logger.debug('Status bar updated:', status);
+	}
+
+	/**
+	 * Set a free-form progress message shown while SYNCING (e.g. "42/361 files").
+	 * Cleared automatically when status changes away from SYNCING.
+	 */
+	setProgress(message: string | undefined): void {
+		this.progressMessage = message;
+		if (this.currentStatus === SyncStatus.SYNCING) {
+			this.updateDisplay();
+		}
 	}
 
 	/**
@@ -85,7 +100,7 @@ export class StatusBarManager {
 
 			case SyncStatus.SYNCING:
 				setIcon(iconEl, 'cloud');
-				textEl.setText('Syncing...');
+				textEl.setText(this.progressMessage ? `Syncing: ${this.progressMessage}` : 'Syncing...');
 				this.statusBarItem.addClass('is-syncing');
 				this.statusBarItem.removeClass('has-error');
 				this.addLoadingAnimation(iconEl);

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -159,6 +159,14 @@ function isInstalledPluginBinaryPath(path: string): boolean {
 }
 
 const LOG_NOTE_FOLDER = '_OneDriveSyncLogs/';
+const OWN_PLUGIN_FOLDER = '.obsidian/plugins/obsidian-onedrive/';
+
+// `workspace.json` and its per-device variants (`workspace-<host>.json`,
+// `workspace-<host>-N.json`, plus the mobile/legacy `workspace-mobile.json`)
+// hold local UI state — open tabs, pane layout, cursor positions. They change
+// constantly on every device and produce nothing but conflict noise when
+// synced. Obsidian Sync excludes them by default; we do the same.
+const WORKSPACE_STATE_PATTERN = /^\.obsidian\/workspace(-[^/]+)?\.json$/;
 
 /**
  * Check whether a vault path should be synced.
@@ -170,6 +178,18 @@ export function shouldSyncVaultPath(path: string, syncPluginManifests = false, s
 	// own. The leading underscore is on the folder, so users who want to share a
 	// specific day's log can simply move that file out of the folder.
 	if (normalized === LOG_NOTE_FOLDER.slice(0, -1) || normalized.startsWith(LOG_NOTE_FOLDER)) {
+		return false;
+	}
+
+	// Never sync the OneDrive plugin's own folder. Auth state in data.json must
+	// stay device-local, and syncing main.js across devices would let an older
+	// install on one device silently downgrade a newer install on another.
+	if (normalized === OWN_PLUGIN_FOLDER.slice(0, -1) || normalized.startsWith(OWN_PLUGIN_FOLDER)) {
+		return false;
+	}
+
+	// Never sync Obsidian's per-device workspace state.
+	if (WORKSPACE_STATE_PATTERN.test(normalized)) {
 		return false;
 	}
 

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -1096,3 +1096,73 @@ describe('SyncEngine first-sync local vault enumeration', () => {
 		expect(mockFileOps.uploadFile).not.toHaveBeenCalled();
 	});
 });
+
+
+describe('SyncEngine progress reporting', () => {
+	let stateManager: SyncStateManager;
+	let conflictResolver: ConflictResolver;
+	let mockFileOps: any;
+	let mockClient: any;
+	let mockEventManager: any;
+
+	beforeEach(() => {
+		stateManager = new SyncStateManager();
+		conflictResolver = new ConflictResolver(ConflictResolutionStrategy.LAST_WRITE_WINS);
+		mockFileOps = {
+			uploadFile: vi.fn().mockResolvedValue({ id: 'uploaded-id', size: 100 }),
+			downloadFile: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
+			deleteFile: vi.fn().mockResolvedValue(undefined),
+		};
+		mockClient = {
+			getDelta: vi.fn().mockResolvedValue({ items: [], deltaLink: 'first-delta' }),
+			isSharedDrive: vi.fn().mockReturnValue(false),
+		};
+		mockEventManager = {
+			getDirtyFiles: vi.fn().mockReturnValue([]),
+			clearDirtyFiles: vi.fn(),
+			addDirtyFile: vi.fn(),
+			removeDirtyPaths: vi.fn(),
+			markOwnWrites: vi.fn(),
+		};
+	});
+
+	it('emits phase progress before any operations execute and per-file progress during execution', async () => {
+		const onProgress = vi.fn();
+		const localFiles = [
+			makeTFile('notes/a.md', 5, Date.now()),
+			makeTFile('notes/b.md', 6, Date.now()),
+		];
+		(mockApp.vault.getFiles as Mock).mockReturnValue(localFiles);
+		(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation(
+			(p: string) => localFiles.find((f) => f.path === p) ?? null
+		);
+
+		const engine = new SyncEngine(
+			mockApp as any,
+			mockFileOps,
+			mockClient,
+			stateManager,
+			conflictResolver,
+			mockEventManager,
+			'/remote/root',
+			undefined,
+			undefined,
+			() => true,
+			() => 0,
+			undefined,
+			onProgress
+		);
+
+		await engine.performSync();
+
+		const messages = onProgress.mock.calls.map((c: any[]) => c[0]);
+		// Phase markers are emitted before per-file progress starts.
+		expect(messages).toContain('starting...');
+		expect(messages).toContain('fetching remote changes...');
+		expect(messages).toContain('planning...');
+		// Per-file progress should reach the total operation count.
+		expect(messages).toContain('2/2 files');
+		// Final clear so the status bar drops back to idle.
+		expect(messages[messages.length - 1]).toBeUndefined();
+	});
+});

--- a/tests/unit/utils/pathUtils.test.ts
+++ b/tests/unit/utils/pathUtils.test.ts
@@ -321,5 +321,24 @@ describe('pathUtils', () => {
 			expect(shouldSyncVaultPath('_OneDriveSyncLogsBackup/foo.md')).toBe(true);
 			expect(shouldSyncVaultPath('notes/_OneDriveSyncLogs/x.md')).toBe(true);
 		});
+
+		it('never syncs the OneDrive plugin\'s own folder, even with plugin sync enabled', () => {
+			expect(shouldSyncVaultPath('.obsidian/plugins/obsidian-onedrive')).toBe(false);
+			expect(shouldSyncVaultPath('.obsidian/plugins/obsidian-onedrive/main.js', true, true)).toBe(false);
+			expect(shouldSyncVaultPath('.obsidian/plugins/obsidian-onedrive/manifest.json', true, true)).toBe(false);
+			expect(shouldSyncVaultPath('.obsidian/plugins/obsidian-onedrive/data.json', true, true)).toBe(false);
+			expect(shouldSyncVaultPath('.obsidian/plugins/obsidian-onedrive/styles.css', true, true)).toBe(false);
+			// Other plugins are unaffected.
+			expect(shouldSyncVaultPath('.obsidian/plugins/calendar/main.js', true)).toBe(true);
+		});
+
+		it('never syncs Obsidian per-device workspace state files', () => {
+			expect(shouldSyncVaultPath('.obsidian/workspace.json', true, true)).toBe(false);
+			expect(shouldSyncVaultPath('.obsidian/workspace-mobile.json', true, true)).toBe(false);
+			expect(shouldSyncVaultPath('.obsidian/workspace-JEFFSTEISL7.json', true, true)).toBe(false);
+			expect(shouldSyncVaultPath('.obsidian/workspace-JEFFOFFICE3-6.json', true, true)).toBe(false);
+			// Other .obsidian files still follow the normal rules.
+			expect(shouldSyncVaultPath('.obsidian/app.json', false, true)).toBe(true);
+		});
 	});
 });


### PR DESCRIPTION
## Progress visibility (the original v0.5.4 motivation)
- `SyncEngine` emits phase messages through a new `onProgress` callback:
  `starting`, `fetching remote changes`, `fetching .obsidian changes`, `planning`, then `X/N files` per executed op, and `undefined` to clear.
- `StatusBarManager` gains `setProgress()`. SYNCING text now reads `Syncing: <message>` so users see counts + current phase even after the toast is dismissed.

## Hard-exclude two churn sources
- **`.obsidian/plugins/obsidian-onedrive/`** — never sync the plugin's own folder. Keeps `data.json` (auth state) device-local and prevents an older install on one device from silently downgrading a newer install on another via vault sync.
- **`.obsidian/workspace.json` + `workspace-<host>(-N).json`** — these hold per-device UI state. Saw 16 conflict variants generated in 8 minutes across three devices in practice. Matches Obsidian Sync's default.

## Tests
209 passing (was 206). Added: 1 progress-callback test, 2 path-exclusion tests.