### PR TITLE
Resolve id-only delete delta entries via tracked state

### DIFF
--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -814,7 +814,16 @@ export class SyncEngine {
 		} else if (item.name) {
 			fullPath = item.name;
 		} else {
-			// Deleted or root items may lack name/path
+			// Microsoft Graph delta emits deleted items with only `id` set —
+			// no name, no parentReference. Reverse-resolve via tracked state
+			// so deletes from other devices actually land on this one. If the
+			// id isn't in state (e.g. file was never synced through this
+			// device), we have to give up: returning '' keeps existing
+			// callers safe.
+			if (item.id) {
+				const trackedPath = this.stateManager.getPathByOneDriveId(item.id);
+				if (trackedPath) return trackedPath;
+			}
 			return '';
 		}
 

--- a/src/sync/syncState.ts
+++ b/src/sync/syncState.ts
@@ -139,6 +139,21 @@ export class SyncStateManager {
 	}
 
 	/**
+	 * Reverse-resolve a OneDrive item id to the vault path it is currently
+	 * tracked under. Microsoft Graph delta returns deleted items with only
+	 * an id — no name, no parentReference — so the only way to know which
+	 * local file the deletion refers to is via the id we recorded when the
+	 * file was last uploaded or downloaded.
+	 */
+	getPathByOneDriveId(oneDriveId: string): string | undefined {
+		if (!oneDriveId) return undefined;
+		for (const [path, state] of this.state.fileStates) {
+			if (state.oneDriveId === oneDriveId) return path;
+		}
+		return undefined;
+	}
+
+	/**
 	 * Check if this is the first sync (no state yet)
 	 */
 	isFirstSync(): boolean {

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -1166,3 +1166,80 @@ describe('SyncEngine progress reporting', () => {
 		expect(messages[messages.length - 1]).toBeUndefined();
 	});
 });
+
+
+describe('SyncEngine remote-delete via id-only delta entries', () => {
+	let stateManager: SyncStateManager;
+	let conflictResolver: ConflictResolver;
+	let mockFileOps: any;
+	let mockClient: any;
+	let mockEventManager: any;
+
+	beforeEach(() => {
+		stateManager = new SyncStateManager();
+		conflictResolver = new ConflictResolver(ConflictResolutionStrategy.LAST_WRITE_WINS);
+		mockFileOps = {
+			uploadFile: vi.fn().mockResolvedValue({ id: 'uploaded-id', size: 100 }),
+			downloadFile: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
+			deleteFile: vi.fn().mockResolvedValue(undefined),
+		};
+		mockClient = {
+			getDelta: vi.fn(),
+			isSharedDrive: vi.fn().mockReturnValue(false),
+		};
+		mockEventManager = {
+			getDirtyFiles: vi.fn().mockReturnValue([]),
+			clearDirtyFiles: vi.fn(),
+			addDirtyFile: vi.fn(),
+			removeDirtyPaths: vi.fn(),
+			markOwnWrites: vi.fn(),
+			removeOwnWrite: vi.fn(),
+		};
+		(mockApp.vault.getFiles as Mock).mockReturnValue([]);
+	});
+
+	it('resolves an id-only delete entry to the tracked vault path and queues a local delete', async () => {
+		const targetPath = 'notes/from-other-device.md';
+		const targetId = '48043224B16FF524!sDELETEDONOTHERDEVICE';
+		stateManager.setFileState(targetPath, {
+			path: targetPath,
+			localMtime: 1,
+			remoteHash: 'h',
+			size: 10,
+			remoteModifiedTime: Date.now(),
+			oneDriveId: targetId,
+		});
+		// Pretend the file exists locally so the planner queues the delete op.
+		const file = makeTFile(targetPath, 10, Date.now());
+		(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation(
+			(p: string) => (p === targetPath ? file : null)
+		);
+
+		// Microsoft Graph delete entry: id only, no name, no parentReference.
+		mockClient.getDelta.mockResolvedValue({
+			items: [{ id: targetId, deleted: { state: 'deleted' } } as any],
+			deltaLink: 'next-delta',
+		});
+		// Set a delta link so isFirstSync is false (we don't want the first-sync
+		// short-circuit, which doesn't issue deletes anyway).
+		stateManager.setDeltaLink('prev-delta');
+		stateManager.setLastSyncTime(1);
+
+		const engine = new SyncEngine(
+			mockApp as any,
+			mockFileOps,
+			mockClient,
+			stateManager,
+			conflictResolver,
+			mockEventManager,
+			'/remote/root'
+		);
+
+		await engine.performSync();
+
+		// The file should have been deleted locally via Obsidian's vault API.
+		expect(mockApp.vault.delete).toHaveBeenCalledWith(file);
+		// And its tracked state should be gone so future syncs don't trip on it.
+		expect(stateManager.getFileState(targetPath)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Microsoft Graph's delta API returns deleted items with only the `id` field — no `name`, no `parentReference`. The planner therefore dropped every remote delete on the floor: `remotePathToVaultPath` returned '', `getAbstractFileByPath('')` returned null, no op queued.

Caught in the wild by the inventory-drift warning shipped in v0.5.4 (#25). A phone log showed:

```
Inventory: vaultFiles=605 trackedStates=658 drift=-53
Delta returned 15 raw items (main: total=9 deletes=2 ...); 2 kept after filter (2 deletes)
  Remote: DELETE  (id=...!s38f91b9c...)
  Remote: DELETE  (id=...!s5f9ffd89...)
Sync plan: 0 operations    ← two deletes, zero operations
```

Fix: reverse-resolve id → path via a new `SyncStateManager.getPathByOneDriveId` lookup. The id was stored when the file was last uploaded/downloaded, so this works for any file synced through this device. Files that pre-date the plugin still require the planned ""Reconcile from cloud"" command (#26).

## Tests
210 passing (was 209). Added one test that constructs an id-only delete delta entry and asserts the local file is deleted + tracked state is cleaned up.