### PR TITLE
Expand folder-delete delta entries into per-file deletes

### DIFF
--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -152,6 +152,55 @@ export class SyncEngine {
 				);
 			}
 
+			// Update folder tracking + expand folder-delete entries into
+			// per-file deletes. Microsoft Graph sends folder deletes the same
+			// way it sends file deletes — only an id, no name or parent — so
+			// without this pass we have no way to know which descendants are
+			// gone. Tracked folder state lets us reverse-resolve the id.
+			const synthesizedDeletes: OneDriveItem[] = [];
+			const allDeltaItems = [
+				...deltaResponse.items,
+				...(obsidianDeltaResponse?.items || []),
+			];
+			for (const item of allDeltaItems) {
+				if (!item.folder) continue;
+				if (item.deleted) {
+					const folderPath = item.id
+						? this.stateManager.getFolderPathById(item.id)
+						: undefined;
+					if (!folderPath) {
+						logger.warn(
+							`Folder delete delta entry could not be resolved to a tracked path (id=${item.id}). ` +
+								`Any descendants we knew about will remain until the next reconcile.`
+						);
+						continue;
+					}
+					const descendants = this.stateManager.getFileStatesUnderFolder(folderPath);
+					logger.info(
+						`Folder delete: ${folderPath} (id=${item.id}) → expanding into ${descendants.length} file deletes`
+					);
+					for (const { path, state } of descendants) {
+						synthesizedDeletes.push({
+							id: state.oneDriveId || `synthesized:${path}`,
+							name: undefined as unknown as string,
+							deleted: { state: 'deleted' },
+							file: {} as any,
+							parentReference: { path: '' } as any,
+							// Stash the resolved path so remotePathToVaultPath
+							// short-circuits without needing to consult state.
+							__resolvedVaultPath: path,
+						} as unknown as OneDriveItem);
+					}
+					this.stateManager.removeFolderState(item.id);
+				} else {
+					// Record/refresh the folder so future deletes can be resolved.
+					const folderPath = this.remotePathToVaultPath(item);
+					if (item.id && folderPath) {
+						this.stateManager.setFolderState(item.id, folderPath);
+					}
+				}
+			}
+
 			// Filter remote changes: split general files and .obsidian-scope files by independent delta streams,
 			// applying both the built-in shouldSyncPath check and user-defined .syncIgnore patterns.
 			const remoteChanges = [
@@ -173,6 +222,13 @@ export class SyncEngine {
 						!this.shouldIgnorePath(vaultPath, ignoreMatchers)
 					);
 				}) || []),
+				...synthesizedDeletes.filter((item) => {
+					const vaultPath = this.remotePathToVaultPath(item);
+					return (
+						this.shouldSyncPath(vaultPath) &&
+						!this.shouldIgnorePath(vaultPath, ignoreMatchers)
+					);
+				}),
 			];
 
 			const obsidianRawCount = obsidianDeltaResponse?.items.length || 0;
@@ -184,6 +240,7 @@ export class SyncEngine {
 				`Delta returned ${deltaResponse.items.length + obsidianRawCount} raw items ` +
 					`(main: total=${deltaResponse.items.length} deletes=${mainDeletes} folders=${mainFolders}; ` +
 					`obsidian: total=${obsidianRawCount} deletes=${obsidianDeletes}); ` +
+					`${synthesizedDeletes.length} synthesized from folder deletes; ` +
 					`${remoteChanges.length} kept after filter (${remoteDeletes} deletes)`
 			);
 			for (const item of remoteChanges) {
@@ -808,6 +865,12 @@ export class SyncEngine {
 	 * Convert remote OneDrive path to vault path
 	 */
 	private remotePathToVaultPath(item: OneDriveItem): string {
+		// Short-circuit for synthesized items where we already know the path
+		// (used by folder-delete expansion to avoid an unnecessary state lookup
+		// per child).
+		const stashed = (item as unknown as { __resolvedVaultPath?: string }).__resolvedVaultPath;
+		if (stashed) return stashed;
+
 		let fullPath: string;
 		if (item.parentReference?.path && item.name) {
 			fullPath = `${item.parentReference.path}/${item.name}`;

--- a/src/sync/syncState.ts
+++ b/src/sync/syncState.ts
@@ -15,6 +15,7 @@ export class SyncStateManager {
 		this.state = {
 			lastSyncTime: 0,
 			fileStates: new Map(),
+			folderStates: new Map(),
 		};
 	}
 
@@ -24,6 +25,7 @@ export class SyncStateManager {
 	loadState(data?: {
 		lastSyncTime: number;
 		fileStates: Array<[string, FileState]>;
+		folderStates?: Array<[string, string]>;
 		deltaLink?: string;
 		obsidianDeltaLink?: string;
 	}): void {
@@ -31,6 +33,7 @@ export class SyncStateManager {
 			this.state = {
 				lastSyncTime: 0,
 				fileStates: new Map(),
+				folderStates: new Map(),
 			};
 			return;
 		}
@@ -38,6 +41,7 @@ export class SyncStateManager {
 		this.state = {
 			lastSyncTime: data.lastSyncTime,
 			fileStates: new Map(data.fileStates),
+			folderStates: new Map(data.folderStates || []),
 			deltaLink: data.deltaLink,
 			obsidianDeltaLink: data.obsidianDeltaLink,
 		};
@@ -45,6 +49,7 @@ export class SyncStateManager {
 		logger.debug('Sync state loaded', {
 			lastSyncTime: new Date(data.lastSyncTime).toISOString(),
 			fileCount: this.state.fileStates.size,
+			folderCount: this.state.folderStates.size,
 			hasDeltaLink: !!data.deltaLink,
 			hasObsidianDeltaLink: !!data.obsidianDeltaLink,
 		});
@@ -56,12 +61,14 @@ export class SyncStateManager {
 	prepareForSave(): {
 		lastSyncTime: number;
 		fileStates: Array<[string, FileState]>;
+		folderStates: Array<[string, string]>;
 		deltaLink?: string;
 		obsidianDeltaLink?: string;
 	} {
 		return {
 			lastSyncTime: this.state.lastSyncTime,
 			fileStates: Array.from(this.state.fileStates.entries()),
+			folderStates: Array.from(this.state.folderStates.entries()),
 			deltaLink: this.state.deltaLink,
 			obsidianDeltaLink: this.state.obsidianDeltaLink,
 		};
@@ -154,6 +161,40 @@ export class SyncStateManager {
 	}
 
 	/**
+	 * Record (or update) a folder we know about by its OneDrive id. Tracking
+	 * folders lets us reverse-resolve folder-delete delta entries — which
+	 * arrive with only an id, just like file deletes — into a vault path so
+	 * we can synthesize per-file deletes for everything beneath that folder.
+	 */
+	setFolderState(oneDriveId: string, vaultPath: string): void {
+		if (!oneDriveId) return;
+		this.state.folderStates.set(oneDriveId, vaultPath);
+	}
+
+	getFolderPathById(oneDriveId: string): string | undefined {
+		if (!oneDriveId) return undefined;
+		return this.state.folderStates.get(oneDriveId);
+	}
+
+	removeFolderState(oneDriveId: string): void {
+		this.state.folderStates.delete(oneDriveId);
+	}
+
+	/**
+	 * Return tracked file states whose path lives under the given folder path.
+	 * Matches direct children and any deeper descendants. Used to expand a
+	 * single folder-delete delta entry into per-file delete operations.
+	 */
+	getFileStatesUnderFolder(folderPath: string): Array<{ path: string; state: FileState }> {
+		const prefix = folderPath.endsWith('/') ? folderPath : `${folderPath}/`;
+		const results: Array<{ path: string; state: FileState }> = [];
+		for (const [path, state] of this.state.fileStates) {
+			if (path.startsWith(prefix)) results.push({ path, state });
+		}
+		return results;
+	}
+
+	/**
 	 * Check if this is the first sync (no state yet)
 	 */
 	isFirstSync(): boolean {
@@ -173,6 +214,7 @@ export class SyncStateManager {
 		this.state = {
 			lastSyncTime: 0,
 			fileStates: new Map(),
+			folderStates: new Map(),
 		};
 		logger.debug('Sync reset — cleared delta links, file states, and last sync time');
 	}
@@ -184,6 +226,7 @@ export class SyncStateManager {
 		this.state = {
 			lastSyncTime: 0,
 			fileStates: new Map(),
+			folderStates: new Map(),
 		};
 		logger.debug('Sync state cleared');
 	}

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,10 @@ export interface OneDriveUser {
 export interface SyncState {
 	lastSyncTime: number; // Unix timestamp in milliseconds
 	fileStates: Map<string, FileState>;
+	folderStates: Map<string, string>; // OneDrive folder id → vault path. Needed
+	// so that folder-delete delta entries (which arrive with id only — no name,
+	// no parentReference) can be reverse-resolved to a path and expanded into
+	// per-file deletes for everything we know was beneath that folder.
 	deltaLink?: string; // OneDrive delta API cursor
 	obsidianDeltaLink?: string; // Separate delta cursor for .obsidian scope
 }

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -1243,3 +1243,114 @@ describe('SyncEngine remote-delete via id-only delta entries', () => {
 		expect(stateManager.getFileState(targetPath)).toBeUndefined();
 	});
 });
+
+
+describe('SyncEngine remote folder-delete expansion', () => {
+	let stateManager: SyncStateManager;
+	let conflictResolver: ConflictResolver;
+	let mockFileOps: any;
+	let mockClient: any;
+	let mockEventManager: any;
+
+	beforeEach(() => {
+		stateManager = new SyncStateManager();
+		conflictResolver = new ConflictResolver(ConflictResolutionStrategy.LAST_WRITE_WINS);
+		mockFileOps = {
+			uploadFile: vi.fn().mockResolvedValue({ id: 'uploaded-id', size: 100 }),
+			downloadFile: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
+			deleteFile: vi.fn().mockResolvedValue(undefined),
+		};
+		mockClient = {
+			getDelta: vi.fn(),
+			isSharedDrive: vi.fn().mockReturnValue(false),
+		};
+		mockEventManager = {
+			getDirtyFiles: vi.fn().mockReturnValue([]),
+			clearDirtyFiles: vi.fn(),
+			addDirtyFile: vi.fn(),
+			removeDirtyPaths: vi.fn(),
+			markOwnWrites: vi.fn(),
+			removeOwnWrite: vi.fn(),
+		};
+		(mockApp.vault.getFiles as Mock).mockReturnValue([]);
+	});
+
+	it('expands an id-only folder delete into per-file deletes for every tracked descendant', async () => {
+		const folderId = 'FOLDER-ID-DELETED-ELSEWHERE';
+		const folderPath = "Jeff's Notebook/Dog";
+		stateManager.setFolderState(folderId, folderPath);
+
+		const descendants = [
+			{ path: `${folderPath}/Links.md`, id: 'CHILD-1' },
+			{ path: `${folderPath}/Vet/Visits.md`, id: 'CHILD-2' },
+		];
+		for (const d of descendants) {
+			stateManager.setFileState(d.path, {
+				path: d.path,
+				localMtime: 1,
+				remoteHash: 'h',
+				size: 10,
+				remoteModifiedTime: Date.now(),
+				oneDriveId: d.id,
+			});
+		}
+		// Also track a file OUTSIDE the deleted folder — it must not be touched.
+		stateManager.setFileState('Notes/Other.md', {
+			path: 'Notes/Other.md',
+			localMtime: 1,
+			remoteHash: 'h',
+			size: 10,
+			remoteModifiedTime: Date.now(),
+			oneDriveId: 'OTHER-ID',
+		});
+
+		const localFiles = [
+			makeTFile(descendants[0].path, 10, Date.now()),
+			makeTFile(descendants[1].path, 10, Date.now()),
+			makeTFile('Notes/Other.md', 10, Date.now()),
+		];
+		(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation(
+			(p: string) => localFiles.find((f) => f.path === p) ?? null
+		);
+
+		// Graph delta: a single folder-delete entry with id only.
+		mockClient.getDelta.mockResolvedValue({
+			items: [
+				{
+					id: folderId,
+					deleted: { state: 'deleted' },
+					folder: { childCount: 0 },
+				} as any,
+			],
+			deltaLink: 'next-delta',
+		});
+		stateManager.setDeltaLink('prev-delta');
+		stateManager.setLastSyncTime(1);
+
+		const engine = new SyncEngine(
+			mockApp as any,
+			mockFileOps,
+			mockClient,
+			stateManager,
+			conflictResolver,
+			mockEventManager,
+			'/remote/root'
+		);
+
+		await engine.performSync();
+
+		// Both descendant files should have been deleted locally.
+		const deletedPaths = (mockApp.vault.delete as Mock).mock.calls.map(
+			(c: any[]) => (c[0] as { path: string }).path
+		);
+		expect(deletedPaths).toContain(descendants[0].path);
+		expect(deletedPaths).toContain(descendants[1].path);
+		// The unrelated file outside the folder must remain.
+		expect(deletedPaths).not.toContain('Notes/Other.md');
+		// Tracked state for both descendants should be cleaned up.
+		expect(stateManager.getFileState(descendants[0].path)).toBeUndefined();
+		expect(stateManager.getFileState(descendants[1].path)).toBeUndefined();
+		// Folder state for the deleted folder should be gone.
+		expect(stateManager.getFolderPathById(folderId)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Folder deletions from Graph delta arrive id-only, just like file deletions. v0.5.5 reverse-resolved file ids via tracked state but folders aren't tracked, so a ""Jeff's Notebook/Dog"" delete on one device still left the children stranded on every other device.

This change tracks folder ids in a new `folderStates` map and, when a folder-delete entry arrives, expands it into a synthesized per-file delete entry for every tracked descendant. The expanded entries flow through the existing planner path, so executeOperations deletes them via `vault.delete` and removes their tracked state.

State is persisted alongside fileStates; older save formats load with an empty folder map.

## Tests
211 passing (was 210). Added: a folder with two descendants is deleted by id-only delta entry; assertions confirm both descendants are deleted locally, an unrelated file is untouched, and folder + file tracked states are cleaned up.