### PR TITLE
v0.5.7: Reconcile from cloud + folder pruning + plugin-list self-heal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,13 @@ export default class OneDriveSyncPlugin extends Plugin {
 		// Load settings
 		await this.loadSettings();
 
+		// Self-heal our entry in community-plugins.json. If we're loading,
+		// we're enabled on this device — so don't let a sync from another
+		// device (which may not have had us installed yet) silently remove
+		// us. Without this, the file ping-pongs and we drop off this device
+		// the next time another device's list overwrites ours.
+		await this.ensureSelfInCommunityPluginsList();
+
 		// Initialize core components
 		this.tokenStorage = new TokenStorage();
 		this.syncStateManager = new SyncStateManager();
@@ -145,6 +152,14 @@ export default class OneDriveSyncPlugin extends Plugin {
 				await this.saveSettings();
 				new Notice('Sync state cleared. Running full sync...');
 				await this.triggerManualSync();
+			},
+		});
+
+		this.addCommand({
+			id: 'reconcile-from-cloud',
+			name: 'Reconcile from cloud (cloud-as-truth recovery)',
+			callback: async () => {
+				await this.reconcileFromCloud();
 			},
 		});
 
@@ -744,6 +759,38 @@ ${lines.join('\n')}
 		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 	}
 
+	/**
+	 * Make sure this plugin's id is listed in `.obsidian/community-plugins.json`.
+	 * That file is the list of *enabled* plugins; if a sync from another device
+	 * overwrites it with a version that doesn't include us, we'd silently
+	 * disappear on next Obsidian launch. Since we're running, we're enabled —
+	 * re-add ourselves if missing.
+	 */
+	private async ensureSelfInCommunityPluginsList(): Promise<void> {
+		const path = '.obsidian/community-plugins.json';
+		const adapter = this.app.vault.adapter;
+		const id = this.manifest?.id;
+		if (!id) return;
+		try {
+			let list: string[] = [];
+			if (await adapter.exists(path)) {
+				const raw = await adapter.read(path);
+				try {
+					const parsed = JSON.parse(raw);
+					if (Array.isArray(parsed)) list = parsed.filter((x) => typeof x === 'string');
+				} catch {
+					logger.warn(`community-plugins.json is malformed; rewriting with just ${id}`);
+				}
+			}
+			if (list.includes(id)) return;
+			list.push(id);
+			await adapter.write(path, JSON.stringify(list, null, 2));
+			logger.info(`Self-healed: added ${id} back to community-plugins.json`);
+		} catch (error) {
+			logger.warn('Failed to self-heal community-plugins.json:', error);
+		}
+	}
+
 	async onPluginManifestSyncChanged(enabled: boolean): Promise<void> {
 		if (this.settings.syncPluginManifests === enabled) {
 			return;
@@ -780,6 +827,40 @@ ${lines.join('\n')}
 			'Sync reset. Delta cursors, file states, and last sync time cleared. ' +
 				'Next sync will re-read from OneDrive and reconcile local files.'
 		);
+	}
+
+	/**
+	 * Reconcile the local vault from a full cloud listing. Treats cloud as
+	 * authoritative — local-only files are deleted, remote-only files are
+	 * downloaded. Destructive deletes are confirmed via the large-delete
+	 * modal. See issue #26.
+	 */
+	async reconcileFromCloud(): Promise<void> {
+		if (!this.tokenStorage.hasTokens()) {
+			new Notice('Reconcile from cloud: not connected to OneDrive.');
+			return;
+		}
+		if (!this.isSyncConfigured()) {
+			new Notice('Reconcile from cloud: select a sync folder in settings first.');
+			return;
+		}
+		if (!this.syncEngine) {
+			new Notice('Reconcile from cloud: sync engine not initialized.');
+			return;
+		}
+		if (this.eventManager?.isSyncInProgress()) {
+			new Notice('Reconcile from cloud: a sync is already in progress.');
+			return;
+		}
+		try {
+			this.statusBarManager?.setStatus(SyncStatus.SYNCING);
+			await this.syncEngine.reconcileFromCloud();
+			await this.saveSettings();
+			this.statusBarManager?.setStatus(SyncStatus.IDLE);
+		} catch (error) {
+			this.statusBarManager?.setStatus(SyncStatus.ERROR);
+			throw error;
+		}
 	}
 
 	/**

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -158,6 +158,7 @@ export class SyncEngine {
 			// without this pass we have no way to know which descendants are
 			// gone. Tracked folder state lets us reverse-resolve the id.
 			const synthesizedDeletes: OneDriveItem[] = [];
+			const deletedFolderPaths: string[] = [];
 			const allDeltaItems = [
 				...deltaResponse.items,
 				...(obsidianDeltaResponse?.items || []),
@@ -179,6 +180,7 @@ export class SyncEngine {
 					logger.info(
 						`Folder delete: ${folderPath} (id=${item.id}) → expanding into ${descendants.length} file deletes`
 					);
+					deletedFolderPaths.push(folderPath);
 					for (const { path, state } of descendants) {
 						synthesizedDeletes.push({
 							id: state.oneDriveId || `synthesized:${path}`,
@@ -350,6 +352,12 @@ export class SyncEngine {
 			// Dismiss progress notice
 			progressNotice?.hide();
 			progress(undefined);
+
+			// Prune folders we just emptied via folder-delete expansion. Without
+			// this the per-file deletes leave empty husk folders on disk.
+			if (deletedFolderPaths.length > 0) {
+				await this.pruneEmptyFolders(deletedFolderPaths);
+			}
 
 			// Clear any dirty-file entries for paths we just downloaded,
 			// so they don't boomerang back as uploads on the next cycle
@@ -846,6 +854,47 @@ export class SyncEngine {
 			logger.debug(`Deleted local file ${filePath}`);
 		}
 		this.stateManager.removeFileState(filePath);
+	}
+
+	/**
+	 * Delete folders that became empty after their descendants were removed by
+	 * folder-delete expansion. Walks deepest-first and cascades up: when a
+	 * folder is removed, its parent is reconsidered (it too may now be empty).
+	 *
+	 * Only deletes folders that are actually empty — if the user has unrelated
+	 * files in there (e.g. local-only, never synced), the folder is left alone.
+	 */
+	private async pruneEmptyFolders(folderPaths: string[]): Promise<void> {
+		// Dedupe and sort deepest-first so children are pruned before parents.
+		const candidates = new Set<string>(folderPaths);
+		const sorted = Array.from(candidates).sort(
+			(a, b) => b.split('/').length - a.split('/').length
+		);
+
+		for (const path of sorted) {
+			await this.tryRemoveFolderAndAncestors(path);
+		}
+	}
+
+	private async tryRemoveFolderAndAncestors(folderPath: string): Promise<void> {
+		let current: string | null = folderPath;
+		while (current && current !== '' && current !== '/') {
+			const folder = this.app.vault.getAbstractFileByPath(current);
+			if (!folder) return;
+			// Only TFolder has `children`. Bail if this is a file or untyped.
+			const children = (folder as unknown as { children?: unknown[] }).children;
+			if (!Array.isArray(children)) return;
+			if (children.length > 0) return;
+			try {
+				await this.app.vault.delete(folder);
+				logger.debug(`Pruned empty folder ${current}`);
+			} catch (error) {
+				logger.warn(`Failed to prune empty folder ${current}:`, error);
+				return;
+			}
+			const slash = current.lastIndexOf('/');
+			current = slash > 0 ? current.slice(0, slash) : null;
+		}
 	}
 
 	/**

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -993,4 +993,189 @@ export class SyncEngine {
 		const normalizedPath = normalizePath(path).replace(/^\/+/, '');
 		return ignoreMatchers.some((matcher) => matcher.test(normalizedPath));
 	}
+
+	/**
+	 * Reconcile the local vault from a full cloud listing. Treats cloud as
+	 * authoritative: any local file not present in cloud is deleted; any
+	 * cloud file not present locally is downloaded; size mismatches are
+	 * downloaded too. Use this to recover from delta collapse, files that
+	 * predate plugin installation, or any drift that Reset Sync Token
+	 * can't fix (Reset is upload-biased — it re-uploads local-only files).
+	 *
+	 * Destructive deletes are gated by the same large-delete confirmation
+	 * modal used by normal sync.
+	 */
+	async reconcileFromCloud(): Promise<void> {
+		logger.info('Starting reconcile-from-cloud operation');
+		const progress = (msg: string | undefined) => {
+			try {
+				this.onProgress?.(msg);
+			} catch {
+				// progress reporting must never break sync
+			}
+		};
+
+		try {
+			progress('listing cloud...');
+			const ignoreMatchers = await this.loadIgnoreMatchers();
+
+			// 1. Enumerate the entire remote vault. listAllItems recurses
+			// /children — it returns files AND folders. We only want files
+			// for diffing.
+			const allRemoteItems = await this.oneDriveClient.listAllItems(this.remoteRoot);
+			logger.info(`Reconcile: enumerated ${allRemoteItems.length} remote items`);
+
+			// 2. Build vaultPath -> OneDriveItem map for everything we'd sync.
+			const remoteFiles = new Map<string, OneDriveItem>();
+			for (const item of allRemoteItems) {
+				if (item.folder) continue;
+				const vaultPath = this.remotePathToVaultPath(item);
+				if (!vaultPath) continue;
+				if (!this.shouldSyncPath(vaultPath)) continue;
+				if (this.shouldIgnorePath(vaultPath, ignoreMatchers)) continue;
+				remoteFiles.set(vaultPath, item);
+			}
+
+			// 3. Snapshot local files we'd sync.
+			const localFiles = this.app.vault
+				.getFiles()
+				.filter((f) => this.shouldSyncPath(f.path))
+				.filter((f) => !this.shouldIgnorePath(f.path, ignoreMatchers));
+			const localByPath = new Map<string, TFile>(localFiles.map((f) => [f.path, f]));
+
+			// 4. Plan operations.
+			const operations: SyncOperation[] = [];
+			const localOnly: string[] = [];
+			const remoteOnly: string[] = [];
+			const sizeMismatch: string[] = [];
+
+			for (const local of localFiles) {
+				if (!remoteFiles.has(local.path)) {
+					localOnly.push(local.path);
+					// Encoded as a remote→local delete (download direction, no remoteState).
+					operations.push({
+						path: local.path,
+						direction: SyncDirection.DOWNLOAD,
+						remoteState: undefined,
+					});
+				}
+			}
+
+			for (const [path, item] of remoteFiles) {
+				const local = localByPath.get(path);
+				if (!local) {
+					remoteOnly.push(path);
+					operations.push({
+						path,
+						direction: SyncDirection.DOWNLOAD,
+						remoteState: this.itemToFileState(item),
+					});
+				} else {
+					const remoteSize = item.size || 0;
+					if (local.stat.size !== remoteSize) {
+						sizeMismatch.push(path);
+						operations.push({
+							path,
+							direction: SyncDirection.DOWNLOAD,
+							remoteState: this.itemToFileState(item),
+						});
+					} else {
+						// Same size — assume same content, just refresh tracked state.
+						this.stateManager.setFileState(path, this.itemToFileState(item));
+					}
+				}
+			}
+
+			logger.info(
+				`Reconcile plan: ${operations.length} operations ` +
+					`(localOnly=${localOnly.length} deletes, remoteOnly=${remoteOnly.length} downloads, sizeMismatch=${sizeMismatch.length} re-downloads)`
+			);
+
+			// 5. Large-delete confirmation for the destructive side.
+			const threshold = this.getLargeDeleteThreshold();
+			if (
+				threshold > 0 &&
+				localOnly.length >= threshold &&
+				this.largeDeleteWarningHandler
+			) {
+				logger.warn(
+					`Reconcile would delete ${localOnly.length} local files (threshold ${threshold}). Asking user.`
+				);
+				const decision = await this.largeDeleteWarningHandler({
+					localDeleteCount: localOnly.length,
+					remoteDeleteCount: 0,
+					threshold,
+					sampleLocalDeletes: localOnly.slice(0, 10),
+					sampleRemoteDeletes: [],
+				});
+				if (decision !== 'proceed') {
+					logger.info(`Reconcile cancelled by user (${operations.length} ops aborted)`);
+					new Notice('Reconcile from cloud cancelled.');
+					return;
+				}
+			}
+
+			if (operations.length === 0) {
+				logger.info('Reconcile: nothing to do — local already matches cloud');
+				new Notice('Reconcile from cloud: already in sync.');
+				return;
+			}
+
+			// 6. Execute.
+			let completed = 0;
+			progress(`0/${operations.length} files`);
+			const progressNotice =
+				operations.length >= 5
+					? new Notice(`Reconciling: 0/${operations.length} files...`, 0)
+					: null;
+			await this.executeOperations(operations, () => {
+				completed++;
+				const label = `${completed}/${operations.length} files`;
+				progress(label);
+				if (progressNotice) {
+					progressNotice.setMessage(`Reconciling: ${label}...`);
+				}
+			});
+			progressNotice?.hide();
+			progress(undefined);
+
+			// 7. Local file event listeners may have queued dirty entries while
+			// we were downloading. Clear them — we just authoritatively synced
+			// from cloud, anything pending is stale.
+			this.eventManager.clearDirtyFiles();
+
+			// 8. Advance delta cursors so the next normal sync starts clean.
+			progress('advancing delta cursor...');
+			try {
+				const newDelta = await this.oneDriveClient.getDelta(undefined, this.remoteRoot);
+				this.stateManager.setDeltaLink(newDelta.deltaLink);
+				const shouldSyncObsidianScope =
+					this.shouldSyncPath('.obsidian/community-plugins.json') ||
+					this.shouldSyncPath('.obsidian/app.json');
+				if (shouldSyncObsidianScope) {
+					const newObs = await this.oneDriveClient.getDelta(
+						undefined,
+						this.remoteRoot,
+						'.obsidian'
+					);
+					this.stateManager.setObsidianDeltaLink(newObs.deltaLink);
+				}
+			} catch (error) {
+				logger.warn(
+					'Reconcile: failed to advance delta cursor; next sync will re-enumerate via delta:',
+					error
+				);
+			}
+
+			this.stateManager.setLastSyncTime(Date.now());
+			logger.info(`Reconcile from cloud complete: ${operations.length} operations executed`);
+			new Notice(
+				`Reconcile from cloud complete: ${remoteOnly.length} downloaded, ${localOnly.length} deleted, ${sizeMismatch.length} refreshed.`
+			);
+		} catch (error) {
+			logger.error('Reconcile from cloud failed:', error);
+			new Notice(`Reconcile from cloud failed: ${error}`);
+			throw error;
+		}
+	}
 }

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -20,6 +20,7 @@ interface OneDrivePlugin {
 	onAppSettingsSyncChanged(enabled: boolean): Promise<void>;
 	onPluginManifestSyncChanged(enabled: boolean): Promise<void>;
 	resetSyncToken(): Promise<void>;
+	reconcileFromCloud(): Promise<void>;
 	authenticate(): Promise<void>;
 	disconnect(): void;
 	triggerManualSync(): Promise<void>;
@@ -368,6 +369,22 @@ export class OneDriveSettingTab extends PluginSettingTab {
 					.setWarning()
 					.onClick(async () => {
 						await this.plugin.resetSyncToken();
+					})
+			);
+
+		// Reconcile from cloud (cloud-as-truth recovery — issue #26)
+		new Setting(containerEl)
+			.setName('Reconcile from cloud')
+			.setDesc(
+				'Treat cloud as authoritative. Deletes local files that no longer exist in OneDrive and downloads anything missing. ' +
+					'Use when Reset Sync Token has not cleared stale local files. Destructive — confirmation required for large deletes.'
+			)
+			.addButton((button) =>
+				button
+					.setButtonText('Reconcile from cloud')
+					.setWarning()
+					.onClick(async () => {
+						await this.plugin.reconcileFromCloud();
 					})
 			);
 

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -1354,3 +1354,123 @@ describe('SyncEngine remote folder-delete expansion', () => {
 		expect(stateManager.getFolderPathById(folderId)).toBeUndefined();
 	});
 });
+
+describe('SyncEngine reconcile from cloud', () => {
+	let stateManager: SyncStateManager;
+	let conflictResolver: ConflictResolver;
+	let mockFileOps: any;
+	let mockClient: any;
+	let mockEventManager: any;
+
+	beforeEach(() => {
+		stateManager = new SyncStateManager();
+		conflictResolver = new ConflictResolver(ConflictResolutionStrategy.LAST_WRITE_WINS);
+		mockFileOps = {
+			uploadFile: vi.fn().mockResolvedValue({ id: 'uploaded-id', size: 100 }),
+			downloadFile: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
+			deleteFile: vi.fn().mockResolvedValue(undefined),
+		};
+		mockClient = {
+			listAllItems: vi.fn(),
+			getDelta: vi.fn().mockResolvedValue({ items: [], deltaLink: 'fresh-delta' }),
+			isSharedDrive: vi.fn().mockReturnValue(false),
+		};
+		mockEventManager = {
+			getDirtyFiles: vi.fn().mockReturnValue([]),
+			clearDirtyFiles: vi.fn(),
+			addDirtyFile: vi.fn(),
+			removeDirtyPaths: vi.fn(),
+			markOwnWrites: vi.fn(),
+			removeOwnWrite: vi.fn(),
+		};
+	});
+
+	it('deletes local-only files, downloads remote-only files, refreshes matching files', async () => {
+		// Cloud: A.md (matches local size), B.md (only in cloud), C.md (size mismatch)
+		mockClient.listAllItems.mockResolvedValue([
+			makeRemoteFile('A.md', { size: 10 }),
+			makeRemoteFile('B.md', { size: 20 }),
+			makeRemoteFile('C.md', { size: 30 }),
+		]);
+
+		// Local: A.md (size 10), C.md (size 99 — mismatch), D.md (local-only, should be deleted)
+		const localFiles = [
+			makeTFile('A.md', 10, Date.now()),
+			makeTFile('C.md', 99, Date.now()),
+			makeTFile('D.md', 5, Date.now()),
+		];
+		(mockApp.vault.getFiles as Mock).mockReturnValue(localFiles);
+		(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation(
+			(p: string) => localFiles.find((f) => f.path === p) ?? null
+		);
+
+		const engine = new SyncEngine(
+			mockApp as any,
+			mockFileOps,
+			mockClient,
+			stateManager,
+			conflictResolver,
+			mockEventManager,
+			'/remote/root'
+		);
+
+		await engine.reconcileFromCloud();
+
+		// D.md (local-only) should have been deleted via vault.delete
+		const deletedPaths = (mockApp.vault.delete as Mock).mock.calls.map(
+			(c: any[]) => (c[0] as { path: string }).path
+		);
+		expect(deletedPaths).toContain('D.md');
+		expect(deletedPaths).not.toContain('A.md');
+
+		// B.md and C.md should have been downloaded (size-mismatch counts as download)
+		const downloadedIds = (mockFileOps.downloadFile as Mock).mock.calls.map((c: any[]) => c[0]);
+		expect(downloadedIds).toContain('B.md-id');
+		expect(downloadedIds).toContain('C.md-id');
+		expect(downloadedIds).not.toContain('A.md-id');
+
+		// A.md (matching size) should have tracked state refreshed without downloading
+		expect(stateManager.getFileState('A.md')).toBeDefined();
+
+		// Delta cursor should have been advanced
+		expect(mockClient.getDelta).toHaveBeenCalled();
+		expect(stateManager.getDeltaLink()).toBe('fresh-delta');
+	});
+
+	it('skips destructive deletes when user declines large-delete confirmation', async () => {
+		// Cloud is empty; local has 10 files — all would be deleted.
+		mockClient.listAllItems.mockResolvedValue([]);
+		const localFiles = Array.from({ length: 10 }, (_, i) =>
+			makeTFile(`Note${i}.md`, 10, Date.now())
+		);
+		(mockApp.vault.getFiles as Mock).mockReturnValue(localFiles);
+		(mockApp.vault.getAbstractFileByPath as Mock).mockImplementation(
+			(p: string) => localFiles.find((f) => f.path === p) ?? null
+		);
+
+		const handler = vi.fn().mockResolvedValue('cancel');
+
+		const engine = new SyncEngine(
+			mockApp as any,
+			mockFileOps,
+			mockClient,
+			stateManager,
+			conflictResolver,
+			mockEventManager,
+			'/remote/root',
+			undefined,
+			undefined,
+			(p) => shouldSyncVaultPath(p),
+			() => 5, // threshold 5
+			handler
+		);
+
+		await engine.reconcileFromCloud();
+
+		expect(handler).toHaveBeenCalledTimes(1);
+		// No deletes should have happened.
+		expect((mockApp.vault.delete as Mock).mock.calls.length).toBe(0);
+		// Cursor should NOT have been advanced when user cancelled.
+		expect(mockClient.getDelta).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Bundle of 3 fixes:

1. **Reconcile from cloud** (#26) — new command/button that treats cloud as authoritative. Deletes local-only files (with large-delete confirmation), downloads remote-only files, refreshes matching files, advances delta cursor. Recovery path for when Reset Sync Token's upload-bias can't fix the vault.

2. **Prune empty folders after folder-delete expansion** — v0.5.6 expanded folder deletes into per-file deletes but left empty folders on disk. Now walks deepest-first, removes empty folders, cascades to ancestors. Only deletes if actually empty.

3. **Self-heal \community-plugins.json\** — on load, re-add ourselves to the enabled-plugins list if a sync from another device dropped us.

213 tests passing (added 2 for reconcile flow).