### PR TITLE
Fix config file/folder cloud-delete sync and 404-on-delete handling

### DIFF
--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -370,6 +370,11 @@ export class OneDriveClient {
 			await retryWithBackoff(() => this.client.api(this.getItemEndpoint(itemId)).delete());
 			logger.debug('Item deleted successfully');
 		} catch (error) {
+			// 404 means the item is already gone — that's the outcome we wanted
+			if (error && typeof error === 'object' && 'statusCode' in error && (error as { statusCode: number }).statusCode === 404) {
+				logger.debug(`Item ${itemId} already deleted (404) — treating as success`);
+				return;
+			}
 			logger.error(`Failed to delete item ${itemId}:`, error);
 			throw new OneDriveError(
 				`Failed to delete item: ${error instanceof Error ? error.message : 'Unknown error'}`

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -896,16 +896,17 @@ export class SyncEngine {
 			}
 
 			if (item.deleted) {
-				// Remote delete — delete locally
+				// Remote delete — delete locally (vault files or config files via adapter)
 				const file = this.app.vault.getAbstractFileByPath(vaultPath);
-				if (file) {
+				const isTracked = this.stateManager.getFileState(vaultPath);
+				if (file || isTracked) {
 					operations.push({
 						path: vaultPath,
 						direction: SyncDirection.DOWNLOAD, // "download" the deletion
 						remoteState: undefined,
 					});
 				}
-				// Clean up state
+				// Clean up tracked state regardless — the remote copy is gone
 				this.stateManager.removeFileState(vaultPath);
 				continue;
 			}
@@ -1264,18 +1265,37 @@ export class SyncEngine {
 
 		for (const path of sorted) {
 			const folder = this.app.vault.getAbstractFileByPath(path);
-			if (!folder || !(folder instanceof TFolder)) continue;
-			if (folder.children.length > 0) {
-				logger.debug(
-					`Skipping cloud-deleted folder ${path} — still has ${folder.children.length} local children`
-				);
-				continue;
-			}
-			try {
-				await this.app.fileManager.trashFile(folder);
-				logger.debug(`Deleted local folder (cloud-deleted): ${path}`);
-			} catch (error) {
-				logger.warn(`Failed to delete local folder ${path}:`, error);
+			if (folder && folder instanceof TFolder) {
+				if (folder.children.length > 0) {
+					logger.debug(
+						`Skipping cloud-deleted folder ${path} — still has ${folder.children.length} local children`
+					);
+					continue;
+				}
+				try {
+					await this.app.fileManager.trashFile(folder);
+					logger.debug(`Deleted local folder (cloud-deleted): ${path}`);
+				} catch (error) {
+					logger.warn(`Failed to delete local folder ${path}:`, error);
+				}
+			} else {
+				// Config folders aren't in the vault index — delete via adapter
+				const adapter = this.app.vault.adapter;
+				try {
+					if (await adapter.exists(path)) {
+						const listing = await adapter.list(path);
+						if (listing.files.length > 0 || listing.folders.length > 0) {
+							logger.debug(
+								`Skipping cloud-deleted config folder ${path} — still has local children`
+							);
+							continue;
+						}
+						await adapter.rmdir(path, false);
+						logger.debug(`Deleted local config folder (cloud-deleted): ${path}`);
+					}
+				} catch (error) {
+					logger.warn(`Failed to delete local config folder ${path}:`, error);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Three bugs fixed that caused cloud-side config deletions to not sync locally and 404 errors to abort sync:

### 1. Config file deletes from cloud not applied locally
`planOperations` used `vault.getAbstractFileByPath()` to gate delete operations, which returns null for `.obsidian/` files. Now also checks tracked state so config file deletions from cloud are applied locally via the adapter.

### 2. Config folder cleanup after cloud delete
`deleteCloudDeletedFolders` used the vault API which can't see `.obsidian/` folders. Now falls back to `adapter.list()`/`adapter.rmdir()` for config folders, cleaning up empty plugin directories after their files are deleted.

### 3. 404 on delete treated as fatal error
When deleting a remote item already gone (e.g. after a partial sync failure or 504 outage), the 404 response aborted the entire sync and prevented remaining operations from executing. Now treated as success — the desired outcome (item removed) is already achieved.

### Files changed
- `src/api/oneDriveClient.ts` — Handle 404 in `deleteItem()` as success
- `src/sync/syncEngine.ts` — Config-aware `planOperations` and `deleteCloudDeletedFolders`

### Testing
- 300 tests passing
- Live tested against real vault with cloud-deleted plugins