### PR TITLE
fix: prerelease workflow always updates manifest-beta.json on main

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -36,21 +36,44 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout main branch
+        uses: actions/checkout@v4
         with:
+          ref: main
           token: ${{ secrets.PAT_TOKEN }}
+          fetch-depth: 0  # Fetch all history for merging
 
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: 'npm'
 
-      - run: npm ci
-
       - name: Configure Git
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+
+      - name: Merge triggering branch (if not main)
+        id: merge
+        run: |
+          TRIGGER_BRANCH="${{ github.ref_name }}"
+          echo "Triggered from: $TRIGGER_BRANCH"
+          echo "trigger_branch=$TRIGGER_BRANCH" >> $GITHUB_OUTPUT
+
+          if [[ "$TRIGGER_BRANCH" != "main" ]]; then
+            echo "Merging $TRIGGER_BRANCH into main for build..."
+            git fetch origin "$TRIGGER_BRANCH"
+            git merge --no-commit --no-ff "origin/$TRIGGER_BRANCH" || {
+              echo "::error::Merge conflict - please merge $TRIGGER_BRANCH into main first"
+              exit 1
+            }
+            echo "merged=true" >> $GITHUB_OUTPUT
+          else
+            echo "Already on main, no merge needed"
+            echo "merged=false" >> $GITHUB_OUTPUT
+          fi
+
+      - run: npm ci
 
       - name: Bump beta version
         id: bump
@@ -113,19 +136,41 @@ jobs:
             fs.writeFileSync('manifest-beta.json', JSON.stringify(m, null, '\t') + '\n');
           "
 
-      - name: Commit and tag
-        run: |
-          git add manifest-beta.json
-          git commit -m "Beta pre-release ${{ steps.bump.outputs.version }}"
-          git tag "${{ steps.bump.outputs.version }}"
-          git push origin HEAD:${{ github.ref_name }}
-          git push origin --tags
-
       - name: Build
         run: npm run build
 
       - name: Prepare beta manifest for release
         run: cp manifest-beta.json manifest.json
+
+      - name: Commit version bump to main
+        run: |
+          # Reset merge changes, keep only manifest-beta.json update
+          if [[ "${{ steps.merge.outputs.merged }}" == "true" ]]; then
+            # We merged a branch - reset to main, then apply only manifest-beta.json change
+            git reset --hard origin/main
+            # Re-apply the version bump
+            node -e "
+              const fs = require('fs');
+              const m = JSON.parse(fs.readFileSync('manifest-beta.json', 'utf8'));
+              m.version = '${{ steps.bump.outputs.version }}';
+              fs.writeFileSync('manifest-beta.json', JSON.stringify(m, null, '\t') + '\n');
+            "
+          fi
+
+          git add manifest-beta.json
+          git commit -m "Beta pre-release ${{ steps.bump.outputs.version }}"
+          git tag "${{ steps.bump.outputs.version }}"
+          git push origin main
+          git push origin --tags
+
+      - name: Rebuild with merged code for release artifacts
+        if: steps.merge.outputs.merged == 'true'
+        run: |
+          # Merge the branch again for building release artifacts
+          git merge --no-commit --no-ff "origin/${{ steps.merge.outputs.trigger_branch }}"
+          npm ci
+          npm run build
+          cp manifest-beta.json manifest.json
 
       - name: Attest build artifacts
         uses: actions/attest-build-provenance@v2
@@ -142,6 +187,8 @@ jobs:
           name: "Beta ${{ steps.bump.outputs.version }}"
           prerelease: true
           generate_release_notes: true
+          body: |
+            ${{ steps.merge.outputs.merged == 'true' && format('Built from branch: `{0}`', steps.merge.outputs.trigger_branch) || 'Built from `main`' }}
           files: |
             main.js
             manifest.json

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -47,6 +47,59 @@ obsidian-onedrive/
 └── package.json       # Dependencies and scripts
 ```
 
+## Release Workflows
+
+### Stable Releases
+
+Use the release workflow to create a new stable release:
+
+```bash
+gh workflow run release.yml -f bump_type=patch   # Bug fixes (1.2.3 → 1.2.4)
+gh workflow run release.yml -f bump_type=minor   # New features (1.2.3 → 1.3.0)
+gh workflow run release.yml -f bump_type=major   # Breaking changes (1.2.3 → 2.0.0)
+```
+
+The workflow:
+1. Runs tests
+2. Bumps version in `manifest.json`, `package.json`, and `versions.json`
+3. Commits and tags on `main`
+4. Builds and creates a GitHub release
+
+**Never create releases manually** with `gh release create` — always use the workflow.
+
+### Beta Pre-Releases (BRAT)
+
+Use the prerelease workflow for beta testing via [BRAT](https://github.com/TfTHacker/obsidian42-brat):
+
+```bash
+gh workflow run prerelease.yml -f bump_type=patch-beta   # 1.2.3 → 1.2.4-beta.0
+gh workflow run prerelease.yml -f bump_type=minor-beta   # 1.2.3 → 1.3.0-beta.0
+gh workflow run prerelease.yml -f bump_type=major-beta   # 1.2.3 → 2.0.0-beta.0
+```
+
+**Key feature:** You can trigger a prerelease from any branch:
+- From `main`: Builds and releases current main code
+- From a feature branch: Builds from that branch's code, but commits `manifest-beta.json` to `main`
+
+This allows testing unmerged PR code via BRAT without polluting PR branches with version bumps.
+
+The workflow:
+1. Checks out `main`
+2. Merges the triggering branch (if not main) for the build
+3. Bumps `manifest-beta.json` version
+4. Commits only `manifest-beta.json` to `main`
+5. Builds artifacts from merged code
+6. Creates a GitHub pre-release
+
+If there's a merge conflict, the workflow fails with a clear error — resolve the conflict first.
+
+### Version Files
+
+- `manifest.json` — Stable version (used by Obsidian Community Plugins)
+- `manifest-beta.json` — Beta version (used by BRAT)
+- `package.json` — NPM package version (kept in sync with stable)
+- `versions.json` — Version history for Obsidian compatibility
+
 ## Guidelines
 
 - Follow existing code style (`npm run format`)


### PR DESCRIPTION
## Summary

Fixes #57 - Updates the prerelease workflow to always commit manifest-beta.json changes to main, even when triggered from a feature branch.

## Problem

Previously, the prerelease workflow committed version bumps to whatever branch triggered it. This caused issues when triggering from feature branches:
- manifest-beta.json only lives on main
- Version bumps on PR branches got lost or caused conflicts
- BRAT users expect prereleases tagged from main

## Solution

The updated workflow:
1. **Always checks out main** first
2. **Merges the triggering branch** (if not main) for the build
3. **Builds artifacts** from the merged code
4. **Commits only manifest-beta.json** to main (not the merged changes)
5. **Tags and releases** from main
6. **Fails gracefully** if there's a merge conflict (user must resolve first)

## Changes

- Checkout main with fetch-depth: 0 for full history
- Add merge step that handles non-main branches
- Reset to main before committing version bump
- Rebuild with merged code after commit
- Add release note indicating which branch was built

## Testing

- [ ] Trigger prerelease from main - should work as before
- [ ] Trigger prerelease from a feature branch - should build from branch, commit to main