### PR TITLE
fix: remove duplicate connect/disconnect notices

### DIFF
--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -110,13 +110,12 @@ export class OneDriveSettingTab extends PluginSettingTab {
 			);
 
 			// Disconnect button
-			statusSetting.addButton((button) =>
-				button.setButtonText(t('settings.auth.connectionStatus.disconnect')).onClick(async () => {
-					this.plugin.disconnect();
-					new Notice(t('settings.auth.connectionStatus.disconnectSuccess'));
-					this.display(); // Refresh settings
-				})
-			);
+				statusSetting.addButton((button) =>
+					button.setButtonText(t('settings.auth.connectionStatus.disconnect')).onClick(async () => {
+						this.plugin.disconnect();
+						this.display(); // Refresh settings
+					})
+				);
 		} else {
 			statusSetting.setDesc(t('settings.auth.connectionStatus.notConnected'));
 
@@ -124,20 +123,19 @@ export class OneDriveSettingTab extends PluginSettingTab {
 			statusSetting.addButton((button) =>
 				button
 					.setButtonText(t('settings.auth.connectionStatus.connect'))
-					.setCta()
-					.onClick(async () => {
-						try {
-							await this.plugin.authenticate();
-							new Notice(t('settings.auth.connectionStatus.connectSuccess'));
-							this.display(); // Refresh settings
-						} catch (error) {
-							new Notice(
-								t('settings.auth.connectionStatus.connectFailed', {
-									message:
-										error instanceof Error
-											? error.message
-											: t('settings.auth.connectionStatus.unknownError'),
-								})
+						.setCta()
+						.onClick(async () => {
+							try {
+								await this.plugin.authenticate();
+								this.display(); // Refresh settings
+							} catch (error) {
+								new Notice(
+									t('settings.auth.connectionStatus.connectFailed', {
+										message:
+											error instanceof Error
+												? error.message
+												: t('settings.auth.connectionStatus.unknownError'),
+									})
 							);
 						}
 					})


### PR DESCRIPTION
Settings UI was showing its own notice after calling \plugin.authenticate()\ and \plugin.disconnect()\, which already show notices. This caused duplicate notifications appearing on connect/disconnect actions.

**Changes:**
- Removed duplicate \connectSuccess\ notice from settings connect button handler
- Removed duplicate \disconnectSuccess\ notice from settings disconnect button handler

The notices in \main.ts\ remain as the single source of truth for these notifications.