### PR TITLE
Allow selecting the OneDrive drive root as the sync folder

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -102,6 +102,7 @@ export const de = {
 	folderBrowser: {
 		title: 'OneDrive-Ordner auswählen',
 		selectCurrent: '"/{{path}}" auswählen',
+		selectRoot: 'Gesamtes {{label}} auswählen (Stammverzeichnis)',
 		useThisFolder: 'Diesen Ordner verwenden',
 		loading: 'Ordner werden geladen...',
 		noSubfolders: 'Keine Unterordner',
@@ -110,6 +111,13 @@ export const de = {
 		items: '{{count}} Elemente',
 		loadError: 'Fehler beim Laden der Ordner: {{message}}',
 		unknownError: 'Unbekannter Fehler',
+	},
+	rootFolderWarning: {
+		title: 'Gesamtes OneDrive synchronisieren?',
+		body: 'Sie haben das OneDrive-Stammverzeichnis ausgewählt. Jede Datei auf Ihrem Laufwerk wird in diesen Tresor synchronisiert, und an einem Ort gelöschte Dateien werden auch am anderen gelöscht.',
+		hint: 'Das ist normalerweise nicht gewünscht. Wählen Sie stattdessen einen eigenen Unterordner.',
+		cancel: 'Abbrechen',
+		confirm: 'Gesamtes Laufwerk synchronisieren',
 	},
 	authModal: {
 		title: 'Mit OneDrive verbinden',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -102,6 +102,7 @@ export const en = {
 	folderBrowser: {
 		title: 'Select OneDrive Folder',
 		selectCurrent: 'Select "/{{path}}"',
+		selectRoot: 'Select the entire {{label}} (root)',
 		useThisFolder: 'Use this folder',
 		loading: 'Loading folders...',
 		noSubfolders: 'No subfolders',
@@ -110,6 +111,13 @@ export const en = {
 		items: '{{count}} items',
 		loadError: 'Error loading folders: {{message}}',
 		unknownError: 'Unknown error',
+	},
+	rootFolderWarning: {
+		title: 'Sync your entire OneDrive?',
+		body: 'You selected the OneDrive root. Every file on your drive will be synced into this vault, and files deleted in either place will be deleted in the other.',
+		hint: 'This is usually not what you want. Consider selecting a dedicated subfolder instead.',
+		cancel: 'Cancel',
+		confirm: 'Sync entire drive',
 	},
 	authModal: {
 		title: 'Connect to OneDrive',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -102,6 +102,7 @@ export const es = {
 	folderBrowser: {
 		title: 'Seleccionar carpeta de OneDrive',
 		selectCurrent: 'Seleccionar "/{{path}}"',
+		selectRoot: 'Seleccionar todo {{label}} (raíz)',
 		useThisFolder: 'Usar esta carpeta',
 		loading: 'Cargando carpetas...',
 		noSubfolders: 'Sin subcarpetas',
@@ -110,6 +111,13 @@ export const es = {
 		items: '{{count}} elementos',
 		loadError: 'Error al cargar carpetas: {{message}}',
 		unknownError: 'Error desconocido',
+	},
+	rootFolderWarning: {
+		title: '¿Sincronizar todo tu OneDrive?',
+		body: 'Seleccionaste la raíz de OneDrive. Cada archivo de tu unidad se sincronizará en esta bóveda, y los archivos eliminados en un lugar se eliminarán en el otro.',
+		hint: 'Normalmente esto no es lo que se desea. Considera seleccionar una subcarpeta dedicada.',
+		cancel: 'Cancelar',
+		confirm: 'Sincronizar toda la unidad',
 	},
 	authModal: {
 		title: 'Conectar a OneDrive',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -102,6 +102,7 @@ export const fr = {
 	folderBrowser: {
 		title: 'Sélectionner un dossier OneDrive',
 		selectCurrent: 'Sélectionner "/{{path}}"',
+		selectRoot: 'Sélectionner tout le {{label}} (racine)',
 		useThisFolder: 'Utiliser ce dossier',
 		loading: 'Chargement des dossiers...',
 		noSubfolders: 'Aucun sous-dossier',
@@ -110,6 +111,13 @@ export const fr = {
 		items: '{{count}} éléments',
 		loadError: 'Erreur lors du chargement des dossiers: {{message}}',
 		unknownError: 'Erreur inconnue',
+	},
+	rootFolderWarning: {
+		title: 'Synchroniser tout votre OneDrive ?',
+		body: 'Vous avez sélectionné la racine OneDrive. Chaque fichier de votre lecteur sera synchronisé dans ce coffre, et les fichiers supprimés d\'un côté seront supprimés de l\'autre.',
+		hint: 'Ce n\'est généralement pas souhaitable. Envisagez plutôt de sélectionner un sous-dossier dédié.',
+		cancel: 'Annuler',
+		confirm: 'Synchroniser tout le lecteur',
 	},
 	authModal: {
 		title: 'Connecter à OneDrive',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -102,6 +102,7 @@ export const it = {
 	folderBrowser: {
 		title: 'Seleziona cartella OneDrive',
 		selectCurrent: 'Seleziona "/{{path}}"',
+		selectRoot: 'Seleziona tutto {{label}} (radice)',
 		useThisFolder: 'Usa questa cartella',
 		loading: 'Caricamento cartelle...',
 		noSubfolders: 'Nessuna sottocartella',
@@ -110,6 +111,13 @@ export const it = {
 		items: '{{count}} elementi',
 		loadError: 'Errore nel caricamento delle cartelle: {{message}}',
 		unknownError: 'Errore sconosciuto',
+	},
+	rootFolderWarning: {
+		title: 'Sincronizzare tutto il tuo OneDrive?',
+		body: 'Hai selezionato la radice di OneDrive. Ogni file dell\'unità verrà sincronizzato in questo vault e i file eliminati in un punto verranno eliminati nell\'altro.',
+		hint: 'Di solito non è ciò che si desidera. Valuta invece di selezionare una sottocartella dedicata.',
+		cancel: 'Annulla',
+		confirm: 'Sincronizza tutta l\'unità',
 	},
 	authModal: {
 		title: 'Connetti a OneDrive',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -102,6 +102,7 @@ export const ja = {
 	folderBrowser: {
 		title: 'OneDriveフォルダを選択',
 		selectCurrent: '"/{{path}}" を選択',
+		selectRoot: '{{label}} 全体（ルート）を選択',
 		useThisFolder: 'このフォルダを使用',
 		loading: 'フォルダを読み込み中...',
 		noSubfolders: 'サブフォルダなし',
@@ -110,6 +111,13 @@ export const ja = {
 		items: '{{count}} アイテム',
 		loadError: 'フォルダの読み込みエラー: {{message}}',
 		unknownError: '不明なエラー',
+	},
+	rootFolderWarning: {
+		title: 'OneDrive 全体を同期しますか？',
+		body: 'OneDrive のルートを選択しました。ドライブ上のすべてのファイルがこのボールトに同期され、一方で削除したファイルはもう一方でも削除されます。',
+		hint: 'これは通常望ましくありません。代わりに専用のサブフォルダーを選択することを検討してください。',
+		cancel: 'キャンセル',
+		confirm: 'ドライブ全体を同期',
 	},
 	authModal: {
 		title: 'OneDriveに接続',

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -102,6 +102,7 @@ export const pt = {
 	folderBrowser: {
 		title: 'Selecionar pasta do OneDrive',
 		selectCurrent: 'Selecionar "/{{path}}"',
+		selectRoot: 'Selecionar todo o {{label}} (raiz)',
 		useThisFolder: 'Usar esta pasta',
 		loading: 'Carregando pastas...',
 		noSubfolders: 'Sem subpastas',
@@ -110,6 +111,13 @@ export const pt = {
 		items: '{{count}} itens',
 		loadError: 'Erro ao carregar pastas: {{message}}',
 		unknownError: 'Erro desconhecido',
+	},
+	rootFolderWarning: {
+		title: 'Sincronizar todo o seu OneDrive?',
+		body: 'Você selecionou a raiz do OneDrive. Todos os arquivos da sua unidade serão sincronizados neste cofre, e arquivos excluídos em um lugar serão excluídos no outro.',
+		hint: 'Normalmente isso não é o desejado. Considere selecionar uma subpasta dedicada.',
+		cancel: 'Cancelar',
+		confirm: 'Sincronizar unidade inteira',
 	},
 	authModal: {
 		title: 'Conectar ao OneDrive',

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -102,6 +102,7 @@ export const zhCn = {
 	folderBrowser: {
 		title: '选择 OneDrive 文件夹',
 		selectCurrent: '选择“/{{path}}”',
+		selectRoot: '选择整个 {{label}}（根目录）',
 		useThisFolder: '使用此文件夹',
 		loading: '正在加载文件夹...',
 		noSubfolders: '没有子文件夹',
@@ -110,6 +111,13 @@ export const zhCn = {
 		items: '{{count}} 项',
 		loadError: '加载文件夹出错：{{message}}',
 		unknownError: '未知错误',
+	},
+	rootFolderWarning: {
+		title: '同步整个 OneDrive？',
+		body: '您选择了 OneDrive 根目录。云端的每个文件都会同步到此保管库，且在任意一端删除的文件也会在另一端被删除。',
+		hint: '通常这并不是您想要的。请考虑改为选择一个专用的子文件夹。',
+		cancel: '取消',
+		confirm: '同步整个云盘',
 	},
 	authModal: {
 		title: '连接 OneDrive',

--- a/src/main.ts
+++ b/src/main.ts
@@ -352,7 +352,11 @@ export default class OneDriveSyncPlugin extends Plugin {
 			} else if (isAppFolder) {
 				remoteRoot = this.settings.appFolderSubpath || '';
 			} else {
-				remoteRoot = this.settings.remotePath || '';
+				// A remotePath of "/" means the user chose the drive root itself,
+				// which is equivalent to an empty base path (no prefix). Anything
+				// else is a real subfolder path like "/Folder/Sub".
+				const configuredPath = this.settings.remotePath || '';
+				remoteRoot = configuredPath === '/' ? '' : configuredPath;
 			}
 			// For path stripping of delta responses, use the FULL path on the
 			// remote drive down to the vault folder — not just the shared root.

--- a/src/ui/folderBrowserModal.ts
+++ b/src/ui/folderBrowserModal.ts
@@ -4,6 +4,7 @@
 
 import { App, Modal, Setting } from 'obsidian';
 import { OneDriveItem } from '../types';
+import { RootFolderWarningModal } from './modals';
 import { t } from '../i18n';
 
 export interface FolderSelection {
@@ -24,6 +25,8 @@ type FolderListFn = (
 export interface FolderBrowserOptions {
 	/** Label for the root breadcrumb (default: "OneDrive") */
 	rootLabel?: string;
+	/** Show a confirmation warning when the drive root is selected (default: false) */
+	warnOnRootSelect?: boolean;
 }
 
 /**
@@ -36,6 +39,7 @@ export class FolderBrowserModal extends Modal {
 	private contentEl_body: HTMLElement;
 	private loading = false;
 	private rootLabel: string;
+	private warnOnRootSelect: boolean;
 
 	// Track the shared folder info if the user navigated into one
 	private sharedDriveId?: string;
@@ -53,6 +57,7 @@ export class FolderBrowserModal extends Modal {
 		this.listFolders = listFolders;
 		this.onSelect = onSelect;
 		this.rootLabel = options?.rootLabel ?? 'OneDrive';
+		this.warnOnRootSelect = options?.warnOnRootSelect ?? false;
 
 		if (initialPath) {
 			this.currentPath = initialPath.split('/').filter((s) => s.length > 0);
@@ -133,25 +138,45 @@ export class FolderBrowserModal extends Modal {
 			}
 		}
 
-		// Select button for current folder
-		if (this.currentPath.length > 0) {
+		// Select button for the current folder. This is also shown at the drive
+		// root (empty path) so the user can sync their entire OneDrive if desired.
+		// The root can only ever be the user's own drive — shared folders are
+		// always entered at depth >= 1 — so root selection is never "shared".
+		{
+			const isRoot = this.currentPath.length === 0;
 			const selectRow = body.createDiv({ cls: 'onedrive-sync-folder-browser-select-row' });
 			new Setting(selectRow)
-				.setName(t('folderBrowser.selectCurrent', { path: this.currentPath.join('/') }))
+				.setName(
+					isRoot
+						? t('folderBrowser.selectRoot', { label: this.rootLabel })
+						: t('folderBrowser.selectCurrent', { path: this.currentPath.join('/') })
+				)
 				.addButton((btn) =>
 					btn
 						.setButtonText(t('folderBrowser.useThisFolder'))
 						.setCta()
 						.onClick(() => {
 							const isShared = !!(this.sharedDriveId && this.sharedItemId);
-							this.onSelect({
-								path: `/${this.currentPath.join('/')}`,
-								name: this.currentPath[this.sharedAtDepth ?? this.currentPath.length - 1],
-								isShared,
-								driveId: this.sharedDriveId,
-								itemId: this.sharedItemId,
-							});
-							this.close();
+							const commit = () => {
+								this.onSelect({
+									path: `/${this.currentPath.join('/')}`,
+									name: isRoot
+										? this.rootLabel
+										: this.currentPath[this.sharedAtDepth ?? this.currentPath.length - 1],
+									isShared,
+									driveId: this.sharedDriveId,
+									itemId: this.sharedItemId,
+								});
+								this.close();
+							};
+
+							// Syncing the whole drive root is a footgun — confirm first
+							// when the caller opted in (full-drive picker only).
+							if (isRoot && this.warnOnRootSelect) {
+								new RootFolderWarningModal(this.app, commit).open();
+							} else {
+								commit();
+							}
 						})
 				);
 		}

--- a/src/ui/modals.ts
+++ b/src/ui/modals.ts
@@ -121,3 +121,57 @@ export class LargeDeleteWarningModal extends Modal {
 		this.resolveDecision(this.decision);
 	}
 }
+
+/**
+ * Root-folder warning modal
+ *
+ * Shown when the user picks the entire OneDrive drive root as their sync
+ * target. Syncing the root pulls every file on the drive into the vault and
+ * enables delete-tracking across the whole drive, so we make the user
+ * explicitly confirm before proceeding. Closing without confirming is a no-op.
+ */
+export class RootFolderWarningModal extends Modal {
+	private readonly onConfirm: () => void;
+	private confirmed = false;
+
+	constructor(app: App, onConfirm: () => void) {
+		super(app);
+		this.onConfirm = onConfirm;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass('onedrive-root-warning-modal');
+
+		contentEl.createEl('h2', { text: t('rootFolderWarning.title') });
+		contentEl.createEl('p', { text: t('rootFolderWarning.body') });
+		contentEl.createEl('p', { text: t('rootFolderWarning.hint') });
+
+		new Setting(contentEl)
+			.addButton((b) =>
+				b
+					.setButtonText(t('rootFolderWarning.cancel'))
+					.setCta()
+					.onClick(() => {
+						this.close();
+					})
+			)
+			.addButton((b) =>
+				b
+					.setButtonText(t('rootFolderWarning.confirm'))
+					.setWarning()
+					.onClick(() => {
+						this.confirmed = true;
+						this.close();
+					})
+			);
+	}
+
+	onClose() {
+		this.contentEl.empty();
+		if (this.confirmed) {
+			this.onConfirm();
+		}
+	}
+}

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -174,7 +174,9 @@ export class OneDriveSettingTab extends PluginSettingTab {
 									void this.plugin.onRemoteFolderChanged(selection).then(() => {
 										this.display();
 									});
-								}
+								},
+								undefined,
+								{ warnOnRootSelect: true }
 							);
 							modal.open();
 						})


### PR DESCRIPTION
## Summary

The folder picker previously required navigating at least one level deep, so users could not select the OneDrive drive **root** itself as their vault sync target. This was a real limitation (the "Use this folder" button was gated on a non-empty path). This PR allows it, with a guard rail.

## Changes

- **`folderBrowserModal.ts`** — the "Use this folder" button now also renders at the drive root. Root can only ever be the user's **own** drive (shared folders are always entered at depth >= 1), so root selection is never treated as shared.
- **`main.ts`** — a `remotePath` of `/` is mapped to an **empty** `remoteRoot`. This matters because `toOneDrivePath()` prepends `${root}/`, so a literal `/` would produce `//file.md`. Empty root runs against the drive root directly — the same path shared-drive mode already uses.
- **`modals.ts`** — new `RootFolderWarningModal` ("Sync your entire OneDrive?") requiring explicit confirmation, since syncing the whole drive pulls every file in and enables cross-drive delete tracking. Shown **only** for the full-drive picker via a new `warnOnRootSelect` option — App Folder mode root (small, safe) shows no warning.
- **i18n** — added `folderBrowser.selectRoot` and a `rootFolderWarning` block to all 8 locales.

## Testing

- `npm run build` passes
- `npx vitest run` — 405/405 pass
- Deployed to test vault for manual verification.
