### PR TITLE
Ignore Office and OS temp files by default

### DIFF
--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -154,7 +154,14 @@ export class SyncEngine {
 	private readonly useAtomicMoves: boolean;
 	private isSharedDrive: boolean;
 	private remoteRootOnDrive: string;
-	private static readonly DEFAULT_IGNORE_PATTERNS: string[] = [];
+	private static readonly DEFAULT_IGNORE_PATTERNS: string[] = [
+		'~$*',
+		'*.tmp',
+		'.~lock.*#',
+		'.DS_Store',
+		'Thumbs.db',
+		'desktop.ini',
+	];
 	private pendingVaultFolderCreates = new Map<string, Promise<void>>();
 
 	// Options stored as instance properties

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -843,6 +843,87 @@ describe('SyncEngine', () => {
 		expect(mockFileOps.uploadFile).not.toHaveBeenCalled();
 	});
 
+	it('ignores default temporary file patterns for local changes', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		const ignoredPaths = [
+			'~$anything.docx',
+			'~$foo.pptx',
+			'A/B/~$foo.xlsx',
+			'something.tmp',
+			'A/B/something.tmp',
+			'.~lock.file.odt#',
+			'.DS_Store',
+			'A/.DS_Store',
+			'Thumbs.db',
+			'A/Thumbs.db',
+			'desktop.ini',
+			'A/B/desktop.ini',
+		];
+		mockEventManager.getDirtyFiles.mockReturnValue(
+			ignoredPaths.map((path) => ({ path, type: LocalChangeType.MODIFY }))
+		);
+
+		await syncEngine.performSync();
+
+		expect(mockEventManager.removeDirtyPaths).toHaveBeenCalledWith(ignoredPaths);
+		expect(mockFileOps.uploadFile).not.toHaveBeenCalled();
+	});
+
+	it('does not ignore normal files that resemble temporary patterns', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		const normalPaths = ['Notes.md', 'A/B/report.docx', 'photo.png', 'weird~$name.md', 'data.tmpl'];
+		mockEventManager.getDirtyFiles.mockReturnValue(
+			normalPaths.map((path) => ({ path, type: LocalChangeType.MODIFY }))
+		);
+		mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+			makeTFile(path, 100, Date.now())
+		);
+
+		await syncEngine.performSync();
+
+		expect(mockEventManager.removeDirtyPaths).not.toHaveBeenCalled();
+		expect(mockFileOps.uploadFile.mock.calls.map((call) => call[0]).sort()).toEqual(
+			normalPaths.map((path) => `/remote/root/${path}`).sort()
+		);
+	});
+
+	it('filters default temporary file patterns from remote changes and deletes', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		stateManager.setFileState('Thumbs.db', {
+			path: 'Thumbs.db',
+			localMtime: 1,
+			remoteHash: 'thumbs-hash',
+			size: 10,
+			remoteModifiedTime: 2,
+			oneDriveId: 'thumbs-id',
+		});
+		mockClient.getDelta.mockResolvedValue({
+			items: [
+				makeRemoteFile('~$anything.docx', { id: 'office-docx-id' }),
+				makeRemoteFile('~$foo.pptx', { id: 'office-pptx-id' }),
+				makeRemoteFile('A/B/~$foo.xlsx', { id: 'office-xlsx-id' }),
+				makeRemoteFile('something.tmp', { id: 'tmp-root-id' }),
+				makeRemoteFile('A/B/something.tmp', { id: 'tmp-nested-id' }),
+				makeRemoteFile('.~lock.file.odt#', { id: 'libreoffice-lock-id' }),
+				makeRemoteFile('.DS_Store', { id: 'ds-store-root-id' }),
+				makeRemoteFile('A/.DS_Store', { id: 'ds-store-id' }),
+				makeRemoteDelete('Thumbs.db', { id: 'thumbs-id' }),
+				makeRemoteFile('A/Thumbs.db', { id: 'thumbs-nested-id' }),
+				makeRemoteFile('desktop.ini', { id: 'desktop-ini-root-id' }),
+				makeRemoteFile('A/B/desktop.ini', { id: 'desktop-ini-id' }),
+				makeRemoteFile('keep.md', { id: 'keep-id' }),
+			],
+			deltaLink: 'delta-link-2',
+		});
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(makeTFile('keep.md', 10, Date.now()));
+
+		await syncEngine.performSync();
+
+		expect(mockFileOps.downloadFile).toHaveBeenCalledTimes(1);
+		expect(mockFileOps.downloadFile).toHaveBeenCalledWith('keep-id');
+		expect(mockApp.fileManager.trashFile).not.toHaveBeenCalled();
+	});
+
 	it('throws and shows an error notice when sync fails', async () => {
 		mockClient.getDelta.mockRejectedValue(new Error('delta failed'));
 


### PR DESCRIPTION
Closes #87

## Summary
- Add built-in default ignore patterns for common Office owner/lock files and OS temporary metadata files.
- Reuse the existing `.syncIgnore` matcher pipeline so local uploads, remote downloads, and remote deletes are filtered consistently before planning.

## Default patterns added
- `~$*`
- `*.tmp`
- `.~lock.*#`
- `.DS_Store`
- `Thumbs.db`
- `desktop.ini`

## Tests added
- Local dirty paths matching default temp patterns are removed from the dirty queue and not uploaded.
- Normal files, including `weird~$name.md` and `data.tmpl`, still upload.
- Remote temp file changes and deletes are filtered while normal remote files still download.