### PR TITLE
Handle locked-file sync failures resiliently

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -80,6 +80,8 @@ export const de = {
 			conflicts: 'Konflikte',
 			conflictsNeedResolution:
 				'OneDrive-Synchronisierung: {{syncedCount}} {{fileLabel}} synchronisiert, {{conflictCount}} {{conflictLabel}} müssen gelöst werden',
+			completedWithDeferred:
+				'OneDrive sync: {{syncedCount}} {{fileLabel}} synced; {{retryCount}} {{retryLabel}} will retry automatically ({{lockedCount}} locked/deferred)',
 			engineFailed: 'OneDrive-Synchronisierung fehlgeschlagen: {{message}}',
 		},
 		reconcile: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -80,6 +80,8 @@ export const en = {
 			conflicts: 'conflicts',
 			conflictsNeedResolution:
 				'OneDrive sync: {{syncedCount}} {{fileLabel}} synced, {{conflictCount}} {{conflictLabel}} need resolution',
+			completedWithDeferred:
+				'OneDrive sync: {{syncedCount}} {{fileLabel}} synced; {{retryCount}} {{retryLabel}} will retry automatically ({{lockedCount}} locked/deferred)',
 			engineFailed: 'OneDrive sync failed: {{message}}',
 		},
 		reconcile: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -80,6 +80,8 @@ export const es = {
 			conflicts: 'conflictos',
 			conflictsNeedResolution:
 				'Sincronización OneDrive: {{syncedCount}} {{fileLabel}} sincronizados, {{conflictCount}} {{conflictLabel}} necesitan resolución',
+			completedWithDeferred:
+				'OneDrive sync: {{syncedCount}} {{fileLabel}} synced; {{retryCount}} {{retryLabel}} will retry automatically ({{lockedCount}} locked/deferred)',
 			engineFailed: 'Sincronización OneDrive fallida: {{message}}',
 		},
 		reconcile: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -80,6 +80,8 @@ export const fr = {
 			conflicts: 'conflits',
 			conflictsNeedResolution:
 				'Synchronisation OneDrive: {{syncedCount}} {{fileLabel}} synchronisés, {{conflictCount}} {{conflictLabel}} nécessitent une résolution',
+			completedWithDeferred:
+				'OneDrive sync: {{syncedCount}} {{fileLabel}} synced; {{retryCount}} {{retryLabel}} will retry automatically ({{lockedCount}} locked/deferred)',
 			engineFailed: 'Synchronisation OneDrive échouée: {{message}}',
 		},
 		reconcile: {

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -80,6 +80,8 @@ export const it = {
 			conflicts: 'conflitti',
 			conflictsNeedResolution:
 				'Sincronizzazione OneDrive: {{syncedCount}} {{fileLabel}} sincronizzati, {{conflictCount}} {{conflictLabel}} necessitano risoluzione',
+			completedWithDeferred:
+				'OneDrive sync: {{syncedCount}} {{fileLabel}} synced; {{retryCount}} {{retryLabel}} will retry automatically ({{lockedCount}} locked/deferred)',
 			engineFailed: 'Sincronizzazione OneDrive fallita: {{message}}',
 		},
 		reconcile: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -80,6 +80,8 @@ export const ja = {
 			conflicts: '競合',
 			conflictsNeedResolution:
 				'OneDrive同期: {{syncedCount}} {{fileLabel}}を同期、{{conflictCount}} {{conflictLabel}}の解決が必要です',
+			completedWithDeferred:
+				'OneDrive sync: {{syncedCount}} {{fileLabel}} synced; {{retryCount}} {{retryLabel}} will retry automatically ({{lockedCount}} locked/deferred)',
 			engineFailed: 'OneDrive同期に失敗しました: {{message}}',
 		},
 		reconcile: {

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -80,6 +80,8 @@ export const pt = {
 			conflicts: 'conflitos',
 			conflictsNeedResolution:
 				'Sincronização OneDrive: {{syncedCount}} {{fileLabel}} sincronizados, {{conflictCount}} {{conflictLabel}} precisam de resolução',
+			completedWithDeferred:
+				'OneDrive sync: {{syncedCount}} {{fileLabel}} synced; {{retryCount}} {{retryLabel}} will retry automatically ({{lockedCount}} locked/deferred)',
 			engineFailed: 'Sincronização OneDrive falhou: {{message}}',
 		},
 		reconcile: {

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -81,6 +81,8 @@ export const zhCn = {
 			conflicts: '个冲突',
 			conflictsNeedResolution:
 				'OneDrive 同步：已同步 {{syncedCount}} {{fileLabel}}，{{conflictCount}} {{conflictLabel}}需要处理',
+			completedWithDeferred:
+				'OneDrive sync: {{syncedCount}} {{fileLabel}} synced; {{retryCount}} {{retryLabel}} will retry automatically ({{lockedCount}} locked/deferred)',
 			engineFailed: 'OneDrive 同步失败：{{message}}',
 		},
 		reconcile: {

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -75,6 +75,7 @@ import {
 	SyncEngineConflictQueue,
 } from '../types';
 import { logger } from '../utils/logger';
+import { isDeferrableError } from '../utils/errors';
 import {
 	normalizePath,
 	toOneDrivePath,
@@ -141,6 +142,14 @@ interface SyncExecutionResult {
 	completed: number;
 	downloadedPaths: string[];
 	conflictedPaths: string[];
+	failedPaths: string[];
+	deferredPaths: string[];
+}
+
+interface SyncOperationFailure {
+	operation: SyncOperation;
+	error: Error;
+	deferrable: boolean;
 }
 
 /**
@@ -288,7 +297,7 @@ export class SyncEngine {
 			}
 
 			// Phase 4: Execute all planned sync operations with progress tracking
-			const { completed, downloadedPaths, conflictedPaths } = await this.executeSyncOperations(
+			const { completed, downloadedPaths, conflictedPaths, failedPaths, deferredPaths } = await this.executeSyncOperations(
 				operations,
 				progress
 			);
@@ -318,15 +327,47 @@ export class SyncEngine {
 			}
 			this.stateManager.setLastSyncTime(Date.now());
 
-			this.eventManager.clearDirtyFiles();
-			for (const path of conflictedPaths) {
-				this.eventManager.addDirtyFile(path, 'modify');
+			if (failedPaths.length === 0 && conflictedPaths.length === 0) {
+				this.eventManager.clearDirtyFiles();
+			} else {
+				const failedPathSet = new Set(failedPaths);
+				const conflictPathSet = new Set(conflictedPaths);
+				const successfulOperationPaths = operations
+					.filter((operation) => !failedPathSet.has(operation.path) && !conflictPathSet.has(operation.path))
+					.map((operation) => operation.path);
+				const completedFolderPaths = folderChanges.map((change) => change.path);
+				const cleanPaths = Array.from(new Set([
+					...successfulOperationPaths,
+					...completedFolderPaths,
+				]));
+				if (cleanPaths.length > 0) {
+					this.eventManager.removeDirtyPaths(cleanPaths);
+				}
+				for (const path of failedPaths) {
+					this.eventManager.addDirtyFile(path, 'modify');
+				}
+				for (const path of conflictedPaths) {
+					this.eventManager.addDirtyFile(path, 'modify');
+				}
 			}
 
 			logger.debug('Sync operations finished');
 			this.eventManager.markInitialSyncDone();
 
 			const syncedCount = completed - conflictedPaths.length;
+			if (failedPaths.length > 0) {
+				const retryCount = failedPaths.length;
+				const lockedCount = deferredPaths.length;
+				new Notice(
+					t('notices.sync.completedWithDeferred', {
+						syncedCount,
+						fileLabel: t(syncedCount === 1 ? 'notices.sync.file' : 'notices.sync.files'),
+						retryCount,
+						retryLabel: t(retryCount === 1 ? 'notices.sync.file' : 'notices.sync.files'),
+						lockedCount,
+					})
+				);
+			}
 			if (conflictedPaths.length > 0) {
 				new Notice(
 					t('notices.sync.conflictsNeedResolution', {
@@ -822,13 +863,22 @@ export class SyncEngine {
 		progress: ProgressFn
 	): Promise<SyncExecutionResult> {
 		let completed = 0;
+		let finished = 0;
 		const downloadedPaths: string[] = [];
 		const conflictedPaths: string[] = [];
 		progress(t('progress.files', { completed: 0, total: operations.length }));
 		const progressNotice =
 			operations.length >= 5 ? new ProgressNotice(t('progress.syncing'), operations.length) : null;
-		await this.executeOperations(operations, (operation) => {
+		const updateProgress = () => {
+			const progressLabel = t('progress.files', { completed: finished, total: operations.length });
+			progress(progressLabel);
+			if (progressNotice) {
+				progressNotice.update(finished, t('progress.syncing'));
+			}
+		};
+		const failures = await this.executeOperations(operations, (operation) => {
 			completed++;
+			finished++;
 
 			if (operation.direction === SyncDirection.DOWNLOAD) {
 				downloadedPaths.push(operation.path);
@@ -837,11 +887,10 @@ export class SyncEngine {
 				conflictedPaths.push(operation.path);
 			}
 
-			const progressLabel = t('progress.files', { completed, total: operations.length });
-			progress(progressLabel);
-			if (progressNotice) {
-				progressNotice.update(completed, t('progress.syncing'));
-			}
+			updateProgress();
+		}, (failure) => {
+			finished++;
+			updateProgress();
 		});
 		progressNotice?.hide();
 		progress(undefined);
@@ -849,6 +898,10 @@ export class SyncEngine {
 			completed,
 			downloadedPaths,
 			conflictedPaths,
+			failedPaths: failures.map((failure) => failure.operation.path),
+			deferredPaths: failures
+				.filter((failure) => failure.deferrable)
+				.map((failure) => failure.operation.path),
 		};
 	}
 
@@ -1195,20 +1248,47 @@ export class SyncEngine {
 	 */
 	private async executeOperations(
 		operations: SyncOperation[],
-		onComplete: (operation: SyncOperation) => void
-	): Promise<void> {
+		onComplete: (operation: SyncOperation) => void,
+		onFailure?: (failure: SyncOperationFailure) => void
+	): Promise<SyncOperationFailure[]> {
 		const parallelCount = Math.min(this.maxConcurrentOperations, operations.length);
 		let nextIndex = 0;
+		const failures: SyncOperationFailure[] = [];
 
 		await Promise.all(
 			Array.from({ length: parallelCount }, async () => {
 				while (nextIndex < operations.length) {
 					const operation = operations[nextIndex++];
-					await this.executeOperation(operation);
-					onComplete(operation);
+					try {
+						await this.executeOperation(operation);
+						onComplete(operation);
+					} catch (error) {
+						const normalizedError =
+							error instanceof Error ? error : new Error(String(error));
+						const failure: SyncOperationFailure = {
+							operation,
+							error: normalizedError,
+							deferrable: isDeferrableError(normalizedError),
+						};
+						failures.push(failure);
+						if (failure.deferrable) {
+							logger.warn(
+								`Deferred ${operation.direction} for ${operation.path}; will retry next sync:`,
+								normalizedError
+							);
+						} else {
+							logger.error(
+								`Failed ${operation.direction} for ${operation.path}; continuing sync:`,
+								normalizedError
+							);
+						}
+						onFailure?.(failure);
+					}
 				}
 			})
 		);
+
+		return failures;
 	}
 
 	/**
@@ -1937,7 +2017,7 @@ export class SyncEngine {
 			let completed = 0;
 			progress(t('progress.files', { completed: 0, total: operations.length }));
 			const progressNotice = new ProgressNotice(t('progress.reconciling'), operations.length);
-			await this.executeOperations(operations, () => {
+			const failures = await this.executeOperations(operations, () => {
 				completed++;
 				const label = t('progress.files', { completed, total: operations.length });
 				progress(label);
@@ -1945,6 +2025,9 @@ export class SyncEngine {
 			});
 			progressNotice.hide();
 			progress(undefined);
+			if (failures.length > 0) {
+				throw new Error(`Reconcile failed for ${failures.length} operation(s)`);
+			}
 
 			// 7. Local file event listeners may have queued dirty entries while
 			// we were downloading. Clear them — we just authoritatively synced

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -130,7 +130,7 @@ export function isRetryableError(error: Error): boolean {
 		return true;
 	}
 
-	const retryableStatusCodes = [408, 429, 500, 502, 503, 504];
+	const retryableStatusCodes = [408, 423, 429, 500, 501, 502, 503, 504];
 
 	if (error instanceof OneDriveError) {
 		return error.statusCode ? retryableStatusCodes.includes(error.statusCode) : false;
@@ -147,6 +147,26 @@ export function isRetryableError(error: Error): boolean {
 	// Network errors are retryable
 	if (error.message.includes('network') || error.message.includes('timeout')) {
 		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Check if an operation failure should be deferred and retried on a later sync.
+ */
+export function isDeferrableError(error: Error): boolean {
+	const deferrableStatusCodes = [423, 501];
+
+	if (error instanceof OneDriveError) {
+		return error.statusCode ? deferrableStatusCodes.includes(error.statusCode) : false;
+	}
+
+	if (error && typeof error === 'object' && 'statusCode' in error) {
+		const statusCode = (error as unknown as { statusCode: number }).statusCode;
+		if (typeof statusCode === 'number') {
+			return deferrableStatusCodes.includes(statusCode);
+		}
 	}
 
 	return false;

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -53,6 +53,7 @@ import { shouldSyncVaultPath } from '../../../src/utils/pathUtils';
 import {
 	ConflictResolutionStrategy,
 	LocalChangeType,
+	OneDriveError,
 	OneDriveItem,
 	SyncDirection,
 } from '../../../src/types';
@@ -127,6 +128,7 @@ describe('SyncEngine', () => {
 		getDirtyFiles: Mock;
 		clearDirtyFiles: Mock;
 		removeDirtyPaths: Mock;
+		addDirtyFile: Mock;
 		markOwnWrites: Mock;
 		removeOwnWrite: Mock;
 		isOwnWrite: Mock;
@@ -147,6 +149,7 @@ describe('SyncEngine', () => {
 		mockApp.vault.adapter.writeBinary.mockReset().mockResolvedValue(undefined);
 		mockApp.vault.adapter.stat.mockReset().mockResolvedValue(null);
 		mockApp.vault.adapter.list.mockReset().mockResolvedValue({ files: [], folders: [] });
+		mockApp.vault.getRoot.mockReset().mockReturnValue({ path: '', children: [] });
 
 		mockFileOps = {
 			uploadFile: vi.fn().mockResolvedValue(
@@ -181,6 +184,7 @@ describe('SyncEngine', () => {
 			getDirtyFiles: vi.fn().mockReturnValue([]),
 			clearDirtyFiles: vi.fn(),
 			removeDirtyPaths: vi.fn(),
+			addDirtyFile: vi.fn(),
 			markOwnWrites: vi.fn(),
 			removeOwnWrite: vi.fn(),
 			isOwnWrite: vi.fn().mockReturnValue(false),
@@ -862,6 +866,163 @@ describe('SyncEngine', () => {
 		await syncEngine.performSync();
 
 		expect(mockEventManager.clearDirtyFiles).toHaveBeenCalledTimes(1);
+	});
+
+	it('continues after one generic operation failure and persists sync progress', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: 'delta-link-2' });
+		mockEventManager.getDirtyFiles.mockReturnValue([
+			{ path: 'notes/fails.md', type: LocalChangeType.MODIFY },
+			{ path: 'notes/succeeds.md', type: LocalChangeType.MODIFY },
+		]);
+		mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+			makeTFile(path, 100, Date.now())
+		);
+		mockFileOps.uploadFile.mockImplementation(async (remotePath: string) => {
+			if (remotePath.endsWith('/notes/fails.md')) {
+				throw new Error('single upload failed');
+			}
+			return makeRemoteItem({
+				id: 'succeeds-id',
+				name: 'succeeds.md',
+				file: { mimeType: 'text/plain', hashes: { quickXorHash: 'succeeds-hash' } },
+			});
+		});
+
+		await syncEngine.performSync();
+
+		expect(mockFileOps.uploadFile).toHaveBeenCalledTimes(2);
+		expect(stateManager.getDeltaLink()).toBe('delta-link-2');
+		expect(stateManager.getLastSyncTime()).toBeGreaterThan(0);
+		expect(stateManager.getFileState('notes/succeeds.md')).toMatchObject({
+			oneDriveId: 'succeeds-id',
+		});
+		expect(stateManager.getFileState('notes/fails.md')).toBeUndefined();
+		expect(mockEventManager.clearDirtyFiles).not.toHaveBeenCalled();
+		expect(mockEventManager.removeDirtyPaths).toHaveBeenCalledWith(['notes/succeeds.md']);
+		expect(mockEventManager.addDirtyFile).toHaveBeenCalledWith('notes/fails.md', 'modify');
+	});
+
+	it.each([423, 501])('defers HTTP %s failures without aborting the sync', async (statusCode) => {
+		stateManager.setLastSyncTime(Date.now());
+		mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: `delta-link-${statusCode}` });
+		mockEventManager.getDirtyFiles.mockReturnValue([
+			{ path: 'notes/locked.docx', type: LocalChangeType.MODIFY },
+			{ path: 'notes/ok.md', type: LocalChangeType.MODIFY },
+		]);
+		mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+			makeTFile(path, 100, Date.now())
+		);
+		mockFileOps.uploadFile.mockImplementation(async (remotePath: string) => {
+			if (remotePath.endsWith('/notes/locked.docx')) {
+				throw new OneDriveError(`HTTP ${statusCode}`, 'transient', statusCode);
+			}
+			return makeRemoteItem({
+				id: 'ok-id',
+				name: 'ok.md',
+				file: { mimeType: 'text/plain', hashes: { quickXorHash: 'ok-hash' } },
+			});
+		});
+
+		await syncEngine.performSync();
+
+		expect(stateManager.getDeltaLink()).toBe(`delta-link-${statusCode}`);
+		expect(stateManager.getFileState('notes/ok.md')).toMatchObject({ oneDriveId: 'ok-id' });
+		expect(stateManager.getFileState('notes/locked.docx')).toBeUndefined();
+		expect(mockEventManager.addDirtyFile).toHaveBeenCalledWith('notes/locked.docx', 'modify');
+		expect(trackingNotice.calls).toContainEqual([
+			'OneDrive sync: 1 file synced; 1 file will retry automatically (1 locked/deferred)',
+			undefined,
+		]);
+	});
+
+	it('eventually syncs a locked file on a later run after advancing the delta cursor', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		mockClient.getDelta
+			.mockResolvedValueOnce({ items: [], deltaLink: 'delta-link-after-locked' })
+			.mockResolvedValueOnce({ items: [], deltaLink: 'delta-link-after-success' });
+		mockEventManager.getDirtyFiles
+			.mockReturnValueOnce([
+				{ path: 'notes/locked.docx', type: LocalChangeType.MODIFY },
+				{ path: 'notes/other.md', type: LocalChangeType.MODIFY },
+			])
+			.mockReturnValueOnce([{ path: 'notes/locked.docx', type: LocalChangeType.MODIFY }]);
+		mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+			makeTFile(path, 100, Date.now())
+		);
+		mockFileOps.uploadFile.mockImplementation(async (remotePath: string) => {
+			if (remotePath.endsWith('/notes/locked.docx')) {
+				throw new OneDriveError('Locked', 'locked', 423);
+			}
+			return makeRemoteItem({
+				id: 'other-id',
+				name: 'other.md',
+				file: { mimeType: 'text/plain', hashes: { quickXorHash: 'other-hash' } },
+			});
+		});
+
+		await syncEngine.performSync();
+
+		expect(stateManager.getDeltaLink()).toBe('delta-link-after-locked');
+		expect(stateManager.getFileState('notes/locked.docx')).toBeUndefined();
+		expect(mockEventManager.addDirtyFile).toHaveBeenCalledWith('notes/locked.docx', 'modify');
+
+		mockFileOps.uploadFile.mockImplementation(async (remotePath: string) =>
+			makeRemoteItem({
+				id: remotePath.endsWith('/notes/locked.docx') ? 'locked-id' : 'other-id',
+				name: remotePath.split('/').pop() ?? 'uploaded.md',
+				file: { mimeType: 'text/plain', hashes: { quickXorHash: 'uploaded-hash' } },
+			})
+		);
+
+		await syncEngine.performSync();
+
+		expect(stateManager.getDeltaLink()).toBe('delta-link-after-success');
+		expect(stateManager.getFileState('notes/locked.docx')).toMatchObject({
+			oneDriveId: 'locked-id',
+			remoteHash: 'uploaded-hash',
+		});
+		expect(mockEventManager.clearDirtyFiles).toHaveBeenCalledTimes(1);
+	});
+
+	it('collects multiple operation failures while completing the remaining operations', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: 'delta-link-multi' });
+		mockEventManager.getDirtyFiles.mockReturnValue([
+			{ path: 'notes/fails-a.md', type: LocalChangeType.MODIFY },
+			{ path: 'notes/ok-a.md', type: LocalChangeType.MODIFY },
+			{ path: 'notes/fails-b.md', type: LocalChangeType.MODIFY },
+			{ path: 'notes/ok-b.md', type: LocalChangeType.MODIFY },
+		]);
+		mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+			makeTFile(path, 100, Date.now())
+		);
+		mockFileOps.uploadFile.mockImplementation(async (remotePath: string) => {
+			const name = remotePath.split('/').pop() ?? remotePath;
+			if (name.startsWith('fails-')) {
+				throw new Error(`${name} failed`);
+			}
+			return makeRemoteItem({
+				id: `${name}-id`,
+				name,
+				file: { mimeType: 'text/plain', hashes: { quickXorHash: `${name}-hash` } },
+			});
+		});
+
+		await syncEngine.performSync();
+
+		expect(mockFileOps.uploadFile).toHaveBeenCalledTimes(4);
+		expect(stateManager.getDeltaLink()).toBe('delta-link-multi');
+		expect(stateManager.getFileState('notes/ok-a.md')).toBeDefined();
+		expect(stateManager.getFileState('notes/ok-b.md')).toBeDefined();
+		expect(stateManager.getFileState('notes/fails-a.md')).toBeUndefined();
+		expect(stateManager.getFileState('notes/fails-b.md')).toBeUndefined();
+		expect(mockEventManager.addDirtyFile).toHaveBeenCalledWith('notes/fails-a.md', 'modify');
+		expect(mockEventManager.addDirtyFile).toHaveBeenCalledWith('notes/fails-b.md', 'modify');
+		expect(trackingNotice.calls).toContainEqual([
+			'OneDrive sync: 2 files synced; 2 files will retry automatically (0 locked/deferred)',
+			undefined,
+		]);
 	});
 
 	it('backfills missing config file hashes without generating a modify change', async () => {
@@ -2063,7 +2224,7 @@ describe('SyncEngine error handling', () => {
 		expect(errorNotices.length).toBeGreaterThan(0);
 	});
 
-	it('throws and shows error notice when upload fails', async () => {
+	it('keeps syncing and shows retry notice when upload fails', async () => {
 		stateManager.setLastSyncTime(Date.now());
 		mockEventManager.getDirtyFiles.mockReturnValue([
 			{ path: 'notes/test.md', type: LocalChangeType.MODIFY },
@@ -2073,10 +2234,16 @@ describe('SyncEngine error handling', () => {
 
 		const engine = makeEngine();
 
-		await expect(engine.performSync()).rejects.toThrow('Upload failed');
+		await expect(engine.performSync()).resolves.toBeUndefined();
+		expect(stateManager.getDeltaLink()).toBe('delta-link-1');
+		expect(mockEventManager.addDirtyFile).toHaveBeenCalledWith('notes/test.md', 'modify');
+		expect(trackingNotice.calls).toContainEqual([
+			'OneDrive sync: 0 files synced; 1 file will retry automatically (0 locked/deferred)',
+			undefined,
+		]);
 	});
 
-	it('throws and shows error notice when download fails', async () => {
+	it('keeps syncing and shows retry notice when download fails', async () => {
 		stateManager.setLastSyncTime(Date.now());
 		mockClient.getDelta.mockResolvedValue({
 			items: [makeRemoteFile('notes/new.md', { id: 'new-id' })],
@@ -2087,6 +2254,12 @@ describe('SyncEngine error handling', () => {
 
 		const engine = makeEngine();
 
-		await expect(engine.performSync()).rejects.toThrow('Download failed');
+		await expect(engine.performSync()).resolves.toBeUndefined();
+		expect(stateManager.getDeltaLink()).toBe('delta-2');
+		expect(mockEventManager.addDirtyFile).toHaveBeenCalledWith('notes/new.md', 'modify');
+		expect(trackingNotice.calls).toContainEqual([
+			'OneDrive sync: 0 files synced; 1 file will retry automatically (0 locked/deferred)',
+			undefined,
+		]);
 	});
 });

--- a/tests/unit/utils/errors.test.ts
+++ b/tests/unit/utils/errors.test.ts
@@ -19,6 +19,7 @@ import {
 	getRetryDelay,
 	handleAuthErrors,
 	handleSyncErrors,
+	isDeferrableError,
 	isRetryableError,
 	parseHttpError,
 } from '../../../src/utils/errors';
@@ -185,7 +186,7 @@ describe('errors utils', () => {
 			expect(isRetryableError(new RateLimitError('Too many requests', 30))).toBe(true);
 		});
 
-		it.each([408, 429, 500, 502, 503, 504])(
+		it.each([408, 423, 429, 500, 501, 502, 503, 504])(
 			'returns true for retryable OneDriveError status %s',
 			(statusCode) => {
 				expect(isRetryableError(new OneDriveError('Retry me', 'code', statusCode))).toBe(true);
@@ -201,7 +202,7 @@ describe('errors utils', () => {
 			expect(isRetryableError(new Error('timeout while waiting for response'))).toBe(true);
 		});
 
-		it.each([408, 429, 500, 502, 503, 504])(
+		it.each([408, 423, 429, 500, 501, 502, 503, 504])(
 			'returns true for Graph SDK errors with retryable statusCode %s',
 			(statusCode) => {
 				const error = Object.assign(new Error('Graph SDK error'), { statusCode, code: 'UnknownError' });
@@ -216,6 +217,21 @@ describe('errors utils', () => {
 
 		it('returns false for generic errors', () => {
 			expect(isRetryableError(new Error('some other error'))).toBe(false);
+		});
+	});
+
+	describe('isDeferrableError', () => {
+		it.each([423, 501])('returns true for deferrable OneDriveError status %s', (statusCode) => {
+			expect(isDeferrableError(new OneDriveError('Retry later', 'code', statusCode))).toBe(true);
+		});
+
+		it.each([423, 501])('returns true for Graph SDK errors with deferrable statusCode %s', (statusCode) => {
+			const error = Object.assign(new Error('Graph SDK error'), { statusCode });
+			expect(isDeferrableError(error)).toBe(true);
+		});
+
+		it.each([400, 404, 500])('returns false for non-deferrable status %s', (statusCode) => {
+			expect(isDeferrableError(new OneDriveError('Not deferred', 'code', statusCode))).toBe(false);
 		});
 	});
 

--- a/tests/unit/utils/retry.test.ts
+++ b/tests/unit/utils/retry.test.ts
@@ -38,6 +38,21 @@ describe('retryWithBackoff', () => {
 		expect(fn).toHaveBeenCalledTimes(2);
 	});
 
+	it.each([423, 501])('should retry deferrable HTTP %s errors', async (statusCode) => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new OneDriveError(`HTTP ${statusCode}`, 'transient', statusCode))
+			.mockResolvedValue('success');
+
+		const result = await retryWithBackoff(fn, {
+			maxAttempts: 3,
+			initialDelay: 10,
+		});
+
+		expect(result).toBe('success');
+		expect(fn).toHaveBeenCalledTimes(2);
+	});
+
 	it('should not retry on non-retryable errors', async () => {
 		const fn = vi.fn().mockRejectedValue(new Error('Non-retryable error'));
 


### PR DESCRIPTION
## Summary
- Isolate sync operation failures so one locked or failing file no longer aborts the entire run.
- Persist delta cursors and successful file states while preserving dirty paths for failed/deferred operations.
- Treat HTTP 423 Locked and HTTP 501 as retryable/deferrable so locked files retry automatically and eventually converge.
- Add an aggregated non-fatal notice for files that will retry automatically.

Closes #85
Closes #86

## Tests added
- Generic per-operation failure continues remaining operations and persists delta progress.
- HTTP 423 and HTTP 501 deferral behavior leaves files dirty and non-fatal.
- Two-run locked-file convergence: first run defers, second run uploads successfully and tracks the file cleanly.
- Multiple simultaneous operation failures are collected while successful operations complete.
- Retry/error utility coverage for 423 and 501 retryable/deferrable classification.

## Validation
- npm run build
- npx vitest run tests/unit/sync/syncEngine.test.ts tests/unit/utils/errors.test.ts tests/unit/utils/retry.test.ts
- npx vitest run