### PR TITLE
Fix #97: scope app-folder delta to vault subfolder

### DIFF
--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -585,8 +585,15 @@ export class OneDriveClient {
 					nextUrl = `/drives/${this.remoteDriveId}/items/${this.remoteItemId}/delta`;
 				}
 			} else if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
-				if (cleanSubPath) {
-					const encoded = encodePathForGraph(cleanSubPath);
+				// Scope the delta to the vault's subfolder within the app folder.
+				// remotePath is the vault subfolder (e.g. "obsidian_Usumbura"),
+				// subPath narrows further (e.g. the config dir). Without this the
+				// query hit the whole app folder and returned sibling vaults'
+				// files, corrupting the vault (see issue #97).
+				const cleanRemote = remotePath ? remotePath.replace(/^\/+|\/+$/g, '') : '';
+				const fullPath = [cleanRemote, cleanSubPath].filter(Boolean).join('/');
+				if (fullPath) {
+					const encoded = encodePathForGraph(fullPath);
 					nextUrl = `/me/drive/special/approot:/${encoded}:/delta`;
 				} else {
 					nextUrl = '/me/drive/special/approot/delta';

--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -586,7 +586,7 @@ export class OneDriveClient {
 				}
 			} else if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
 				// Scope the delta to the vault's subfolder within the app folder.
-				// remotePath is the vault subfolder (e.g. "obsidian_Usumbura"),
+				// remotePath is the vault subfolder (e.g. "my_vault"),
 				// subPath narrows further (e.g. the config dir). Without this the
 				// query hit the whole app folder and returned sibling vaults'
 				// files, corrupting the vault (see issue #97).

--- a/src/main.ts
+++ b/src/main.ts
@@ -394,6 +394,7 @@ export default class OneDriveSyncPlugin extends Plugin {
 				{
 					remoteRoot,
 					remoteRootOnDrive,
+					isAppFolder,
 					conflictQueue: this.conflictQueue,
 					shouldSyncPath: (path) =>
 						shouldSyncVaultPath(

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -184,6 +184,7 @@ export class SyncEngine {
 	private readonly getNotificationLevel: () => NotificationLevel;
 	private readonly pluginVersion: string;
 	private readonly isPullOnlyMode: () => boolean;
+	private readonly isAppFolder: boolean;
 
 	constructor(
 		private app: App,
@@ -207,6 +208,7 @@ export class SyncEngine {
 		this.maxConcurrentOperations = options.maxConcurrentOperations ?? 4;
 		this.useAtomicMoves = options.useAtomicMoves ?? true;
 		this.isPullOnlyMode = options.isPullOnlyMode ?? (() => false);
+		this.isAppFolder = options.isAppFolder ?? false;
 
 		this.isSharedDrive = oneDriveClient.isSharedDrive();
 		// For shared drives, delta items have paths relative to the remote drive root,
@@ -317,7 +319,7 @@ export class SyncEngine {
 					logger.info('Everything up to date — no operations needed');
 				}
 				if (folderChanges.length === 0 && deletedFolderPaths.length === 0) {
-					this.stateManager.setDeltaLink(deltaResponse.deltaLink);
+					this.stateManager.setDeltaLink(deltaResponse.deltaLink, true);
 					if (obsidianDeltaResponse) {
 						this.stateManager.setObsidianDeltaLink(obsidianDeltaResponse.deltaLink);
 					}
@@ -352,7 +354,7 @@ export class SyncEngine {
 				this.eventManager.removeDirtyPaths(downloadedPaths);
 			}
 
-			this.stateManager.setDeltaLink(deltaResponse.deltaLink);
+			this.stateManager.setDeltaLink(deltaResponse.deltaLink, true);
 			if (obsidianDeltaResponse) {
 				this.stateManager.setObsidianDeltaLink(obsidianDeltaResponse.deltaLink);
 			}
@@ -668,6 +670,28 @@ export class SyncEngine {
 	}
 
 	/**
+	 * Retire a legacy app-folder delta cursor that predates the issue #97 fix.
+	 *
+	 * Before the fix the app-folder delta query ignored the vault subfolder and
+	 * streamed the entire app folder, so a stored cursor could keep returning
+	 * sibling vaults' files (which then got nested into this vault). Such cursors
+	 * lack the `deltaLinkScoped` flag. When we detect one in app-folder mode with
+	 * a subfolder configured, drop it so the next fetch builds a fresh, properly
+	 * scoped cursor. Tracked file/folder state is left intact.
+	 */
+	private retireLegacyUnscopedDeltaLink(): void {
+		if (!this.isAppFolder) return;
+		if (!this.remoteRoot) return; // no subfolder → wide query was already correct
+		if (!this.stateManager.getDeltaLink()) return;
+		if (this.stateManager.isDeltaLinkScoped()) return;
+		logger.warn(
+			'Retiring legacy unscoped app-folder delta cursor (issue #97); ' +
+				'next sync will rebuild a subfolder-scoped cursor.'
+		);
+		this.stateManager.resetDeltaLink();
+	}
+
+	/**
 	 * Fetch remote changes via the OneDrive delta API (two streams: general
 	 * files and .obsidian-scope files), expand folder deletes into per-file
 	 * synthetic deletes, and filter by sync scope + .syncIgnore patterns.
@@ -681,6 +705,7 @@ export class SyncEngine {
 		progress: ProgressFn
 	): Promise<RemoteChangesResult> {
 		progress(t('progress.fetchingRemoteChanges'));
+		this.retireLegacyUnscopedDeltaLink();
 		const deltaLink = this.stateManager.getDeltaLink();
 		const shouldSyncObsidianScope =
 			this.shouldSyncPath(`${this.configDir}/community-plugins.json`) ||

--- a/src/sync/syncState.ts
+++ b/src/sync/syncState.ts
@@ -27,6 +27,7 @@ export class SyncStateManager {
 		fileStates: Array<[string, FileState]>;
 		folderStates?: Array<[string, string]>;
 		deltaLink?: string;
+		deltaLinkScoped?: boolean;
 		obsidianDeltaLink?: string;
 	}): void {
 		if (!data) {
@@ -43,6 +44,7 @@ export class SyncStateManager {
 			fileStates: new Map(data.fileStates),
 			folderStates: new Map(data.folderStates || []),
 			deltaLink: data.deltaLink,
+			deltaLinkScoped: data.deltaLinkScoped,
 			obsidianDeltaLink: data.obsidianDeltaLink,
 		};
 
@@ -51,6 +53,7 @@ export class SyncStateManager {
 			fileCount: this.state.fileStates.size,
 			folderCount: this.state.folderStates.size,
 			hasDeltaLink: !!data.deltaLink,
+			deltaLinkScoped: !!data.deltaLinkScoped,
 			hasObsidianDeltaLink: !!data.obsidianDeltaLink,
 		});
 	}
@@ -63,6 +66,7 @@ export class SyncStateManager {
 		fileStates: Array<[string, FileState]>;
 		folderStates: Array<[string, string]>;
 		deltaLink?: string;
+		deltaLinkScoped?: boolean;
 		obsidianDeltaLink?: string;
 	} {
 		return {
@@ -70,6 +74,7 @@ export class SyncStateManager {
 			fileStates: Array.from(this.state.fileStates.entries()),
 			folderStates: Array.from(this.state.folderStates.entries()),
 			deltaLink: this.state.deltaLink,
+			deltaLinkScoped: this.state.deltaLinkScoped,
 			obsidianDeltaLink: this.state.obsidianDeltaLink,
 		};
 	}
@@ -97,10 +102,34 @@ export class SyncStateManager {
 	}
 
 	/**
-	 * Set delta link after sync
+	 * Set delta link after sync.
+	 *
+	 * @param deltaLink The cursor returned by the delta API.
+	 * @param scoped Whether this cursor was produced by the app-folder scoped
+	 *   query. Post-fix callers pass true so legacy wide cursors (which lack the
+	 *   flag) can be detected and reset once. See issue #97.
 	 */
-	setDeltaLink(deltaLink: string): void {
+	setDeltaLink(deltaLink: string, scoped = false): void {
 		this.state.deltaLink = deltaLink;
+		this.state.deltaLinkScoped = scoped;
+	}
+
+	/**
+	 * Whether the stored main delta cursor is known to be subfolder-scoped.
+	 * False for legacy cursors minted before the issue #97 fix.
+	 */
+	isDeltaLinkScoped(): boolean {
+		return this.state.deltaLinkScoped === true;
+	}
+
+	/**
+	 * Drop the main delta cursor so the next sync starts a fresh (scoped)
+	 * stream. Used to retire a legacy, unscoped app-folder cursor without
+	 * wiping tracked file/folder state.
+	 */
+	resetDeltaLink(): void {
+		this.state.deltaLink = undefined;
+		this.state.deltaLinkScoped = false;
 	}
 
 	/**

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,9 @@ export interface SyncState {
 	// no parentReference) can be reverse-resolved to a path and expanded into
 	// per-file deletes for everything we know was beneath that folder.
 	deltaLink?: string; // OneDrive delta API cursor
+	deltaLinkScoped?: boolean; // true when deltaLink was produced by the scoped
+	// app-folder query (issue #97). Legacy tokens minted before the fix lack this
+	// and are tossed once so a fresh, subfolder-scoped cursor replaces them.
 	obsidianDeltaLink?: string; // Separate delta cursor for .obsidian scope
 }
 
@@ -223,6 +226,12 @@ export interface SyncEngineOptions {
 	useAtomicMoves?: boolean;
 	/** Returns true if pull-only mode is enabled */
 	isPullOnlyMode?: () => boolean;
+	/**
+	 * True when running in app-folder mode. Used to detect and retire a legacy,
+	 * unscoped app-folder delta cursor that could return sibling vaults' files
+	 * (issue #97). Full-access/shared cursors were always scoped.
+	 */
+	isAppFolder?: boolean;
 }
 
 export enum ConflictResolutionStrategy {

--- a/tests/unit/api/oneDriveClient.test.ts
+++ b/tests/unit/api/oneDriveClient.test.ts
@@ -372,6 +372,24 @@ describe('OneDriveClient', () => {
 			expect(mockClient.api).toHaveBeenCalledWith('/me/drive/special/approot/delta');
 		});
 
+		// Issue #97: app-folder delta must be scoped to the vault subfolder,
+		// otherwise it streams sibling vaults in the same app folder.
+		it('scopes the app-folder delta to the vault subfolder (remotePath)', async () => {
+			mockApiGet.mockResolvedValue({ value: [item1], '@odata.deltaLink': 'delta-1' });
+
+			await client.getDelta(undefined, 'obsidian_Usumbura');
+			const encoded = encodePathForGraph('obsidian_Usumbura');
+			expect(mockClient.api).toHaveBeenCalledWith(`/me/drive/special/approot:/${encoded}:/delta`);
+		});
+
+		it('combines remotePath and subPath for the app-folder delta', async () => {
+			mockApiGet.mockResolvedValue({ value: [item1], '@odata.deltaLink': 'delta-1' });
+
+			await client.getDelta(undefined, 'obsidian_Usumbura', '.obsidian');
+			const encoded = encodePathForGraph('obsidian_Usumbura/.obsidian');
+			expect(mockClient.api).toHaveBeenCalledWith(`/me/drive/special/approot:/${encoded}:/delta`);
+		});
+
 		it('uses a full-access remote path delta endpoint on the first call', async () => {
 			const fullAccessClient = new OneDriveClient(mockAuthProvider as any, OneDriveAccessMode.FULL_ACCESS);
 			const encoded = encodePathForGraph('Folder Name/Sub Folder');

--- a/tests/unit/api/oneDriveClient.test.ts
+++ b/tests/unit/api/oneDriveClient.test.ts
@@ -377,16 +377,16 @@ describe('OneDriveClient', () => {
 		it('scopes the app-folder delta to the vault subfolder (remotePath)', async () => {
 			mockApiGet.mockResolvedValue({ value: [item1], '@odata.deltaLink': 'delta-1' });
 
-			await client.getDelta(undefined, 'obsidian_Usumbura');
-			const encoded = encodePathForGraph('obsidian_Usumbura');
+			await client.getDelta(undefined, 'vault_a');
+			const encoded = encodePathForGraph('vault_a');
 			expect(mockClient.api).toHaveBeenCalledWith(`/me/drive/special/approot:/${encoded}:/delta`);
 		});
 
 		it('combines remotePath and subPath for the app-folder delta', async () => {
 			mockApiGet.mockResolvedValue({ value: [item1], '@odata.deltaLink': 'delta-1' });
 
-			await client.getDelta(undefined, 'obsidian_Usumbura', '.obsidian');
-			const encoded = encodePathForGraph('obsidian_Usumbura/.obsidian');
+			await client.getDelta(undefined, 'vault_a', '.obsidian');
+			const encoded = encodePathForGraph('vault_a/.obsidian');
 			expect(mockClient.api).toHaveBeenCalledWith(`/me/drive/special/approot:/${encoded}:/delta`);
 		});
 

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -388,6 +388,61 @@ describe('SyncEngine', () => {
 		});
 	});
 
+	// Issue #97: a legacy (unscoped) app-folder cursor is retired once so the
+	// next fetch rebuilds a subfolder-scoped one.
+	it('retires a legacy unscoped app-folder delta cursor', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		stateManager.setDeltaLink('legacy-wide-cursor'); // no scoped flag
+		syncEngine = new SyncEngine(
+			mockApp as any,
+			mockFileOps as any,
+			mockClient as any,
+			stateManager,
+			conflictResolver,
+			mockEventManager as any,
+			'.obsidian',
+			{
+				remoteRoot: 'obsidian_Usumbura',
+				remoteRootOnDrive: '/Applications/ObsidianOneDrive/obsidian_Usumbura',
+				isAppFolder: true,
+			}
+		);
+		mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: 'fresh-scoped-cursor' });
+
+		await syncEngine.performSync();
+
+		// Fetch was made WITHOUT the legacy cursor (forcing a fresh scoped query)...
+		expect(mockClient.getDelta).toHaveBeenCalledWith(undefined, 'obsidian_Usumbura');
+		// ...and the newly stored cursor is flagged scoped.
+		expect(stateManager.getDeltaLink()).toBe('fresh-scoped-cursor');
+		expect(stateManager.isDeltaLinkScoped()).toBe(true);
+	});
+
+	// A scoped cursor is used as-is, not reset.
+	it('keeps a scoped app-folder delta cursor', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		stateManager.setDeltaLink('already-scoped', true);
+		syncEngine = new SyncEngine(
+			mockApp as any,
+			mockFileOps as any,
+			mockClient as any,
+			stateManager,
+			conflictResolver,
+			mockEventManager as any,
+			'.obsidian',
+			{
+				remoteRoot: 'obsidian_Usumbura',
+				remoteRootOnDrive: '/Applications/ObsidianOneDrive/obsidian_Usumbura',
+				isAppFolder: true,
+			}
+		);
+		mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: 'next-scoped' });
+
+		await syncEngine.performSync();
+
+		expect(mockClient.getDelta).toHaveBeenCalledWith('already-scoped', 'obsidian_Usumbura');
+	});
+
 	it('ignores remote .obsidian plugin files by default', async () => {
 		stateManager.setLastSyncTime(Date.now());
 		mockClient.getDelta.mockResolvedValue({

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -402,8 +402,8 @@ describe('SyncEngine', () => {
 			mockEventManager as any,
 			'.obsidian',
 			{
-				remoteRoot: 'obsidian_Usumbura',
-				remoteRootOnDrive: '/Applications/ObsidianOneDrive/obsidian_Usumbura',
+				remoteRoot: 'vault_a',
+				remoteRootOnDrive: '/Applications/ObsidianOneDrive/vault_a',
 				isAppFolder: true,
 			}
 		);
@@ -412,7 +412,7 @@ describe('SyncEngine', () => {
 		await syncEngine.performSync();
 
 		// Fetch was made WITHOUT the legacy cursor (forcing a fresh scoped query)...
-		expect(mockClient.getDelta).toHaveBeenCalledWith(undefined, 'obsidian_Usumbura');
+		expect(mockClient.getDelta).toHaveBeenCalledWith(undefined, 'vault_a');
 		// ...and the newly stored cursor is flagged scoped.
 		expect(stateManager.getDeltaLink()).toBe('fresh-scoped-cursor');
 		expect(stateManager.isDeltaLinkScoped()).toBe(true);
@@ -431,8 +431,8 @@ describe('SyncEngine', () => {
 			mockEventManager as any,
 			'.obsidian',
 			{
-				remoteRoot: 'obsidian_Usumbura',
-				remoteRootOnDrive: '/Applications/ObsidianOneDrive/obsidian_Usumbura',
+				remoteRoot: 'vault_a',
+				remoteRootOnDrive: '/Applications/ObsidianOneDrive/vault_a',
 				isAppFolder: true,
 			}
 		);
@@ -440,7 +440,7 @@ describe('SyncEngine', () => {
 
 		await syncEngine.performSync();
 
-		expect(mockClient.getDelta).toHaveBeenCalledWith('already-scoped', 'obsidian_Usumbura');
+		expect(mockClient.getDelta).toHaveBeenCalledWith('already-scoped', 'vault_a');
 	});
 
 	it('ignores remote .obsidian plugin files by default', async () => {

--- a/tests/unit/sync/syncState.test.ts
+++ b/tests/unit/sync/syncState.test.ts
@@ -168,6 +168,38 @@ describe('SyncStateManager', () => {
 			stateManager.setLastSyncTime(Date.now());
 			expect(stateManager.isFirstSync()).toBe(false);
 		});
+
+		// Issue #97: distinguish scoped cursors from legacy wide ones.
+		it('marks a delta link scoped only when told to', () => {
+			stateManager.setDeltaLink('wide-legacy');
+			expect(stateManager.isDeltaLinkScoped()).toBe(false);
+
+			stateManager.setDeltaLink('scoped-token', true);
+			expect(stateManager.isDeltaLinkScoped()).toBe(true);
+		});
+
+		it('resetDeltaLink drops the cursor and scoped flag but keeps other state', () => {
+			stateManager.setLastSyncTime(555);
+			stateManager.setDeltaLink('scoped-token', true);
+			stateManager.setFileState('keep.md', makeFileState('keep.md'));
+
+			stateManager.resetDeltaLink();
+
+			expect(stateManager.getDeltaLink()).toBeUndefined();
+			expect(stateManager.isDeltaLinkScoped()).toBe(false);
+			expect(stateManager.getLastSyncTime()).toBe(555);
+			expect(stateManager.getFileState('keep.md')).toBeDefined();
+		});
+
+		it('treats a legacy persisted cursor (no flag) as unscoped', () => {
+			stateManager.loadState({
+				lastSyncTime: 1,
+				deltaLink: 'legacy-wide',
+				fileStates: [],
+			});
+			expect(stateManager.getDeltaLink()).toBe('legacy-wide');
+			expect(stateManager.isDeltaLinkScoped()).toBe(false);
+		});
 	});
 
 	describe('serialization', () => {
@@ -207,6 +239,16 @@ describe('SyncStateManager', () => {
 
 			expect(stateManager.getLastSyncTime()).toBe(0);
 			expect(stateManager.getTrackedPaths()).toEqual([]);
+		});
+
+		it('round-trips the deltaLinkScoped flag through save/load', () => {
+			stateManager.setDeltaLink('scoped-token', true);
+			const serialized = stateManager.prepareForSave();
+			expect(serialized.deltaLinkScoped).toBe(true);
+
+			const fresh = new SyncStateManager();
+			fresh.loadState({ ...serialized });
+			expect(fresh.isDeltaLinkScoped()).toBe(true);
 		});
 	});
 


### PR DESCRIPTION
## Problem (issue #97, point 2)

Users with **two vaults under one OneDrive app folder** saw sibling-vault folders get duplicated into their vault (e.g. a phantom `Applications/ObsidianOneDrive/Obsidian_Ecole/…` tree), which then re-uploaded and snowballed.

**Root cause:** in app-folder mode, `getDelta` ignored the configured vault subfolder (`remotePath`) and queried the **whole app folder** — returning every vault's files. The verbatim-stored delta cursor kept the wide scope alive across syncs.

## Fix (minimal)
1. **Scope the query** — app-folder delta now targets `approot:/<subfolder>[/subPath]:/delta` instead of the whole `approot`.
2. **Toss the legacy token** — track whether a stored cursor came from the scoped query (`deltaLinkScoped`). On sync, if in app-folder mode *with a subfolder* and the cursor is a legacy unscoped one, drop it so the next fetch rebuilds a scoped cursor. Tracked file/folder state is preserved.

## Not included
- No cleanup of `Applications/…` junk already sitting in an affected vault — that's pre-existing local data; auto-deleting it is too risky. Users remove it manually.

## Tests
- `getDelta` scoped-query URL (remotePath, remotePath+subPath).
- `deltaLinkScoped` set/reset + save/load round-trip.
- Legacy cursor retired (fetch made without it, new cursor flagged scoped); scoped cursor kept as-is.

445 tests pass; build clean.