### PR TITLE
Fix #97 follow-up: first-sync 404 regression + reconcile cursor flag

### DIFF
--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -564,6 +564,10 @@ export class OneDriveClient {
 
 		const allItems: OneDriveItem[] = [];
 		const cleanSubPath = subPath ? subPath.replace(/^\/+|\/+$/g, '') : undefined;
+		// Vault subfolder within the remote root (app-folder mode), slash-trimmed.
+		// Hoisted so the not-found recovery below can tell we queried a scoped
+		// target that may not exist remotely yet on a first sync.
+		const cleanRemotePath = remotePath ? remotePath.replace(/^\/+|\/+$/g, '') : '';
 
 		try {
 			let nextUrl: string;
@@ -590,8 +594,7 @@ export class OneDriveClient {
 				// subPath narrows further (e.g. the config dir). Without this the
 				// query hit the whole app folder and returned sibling vaults'
 				// files, corrupting the vault (see issue #97).
-				const cleanRemote = remotePath ? remotePath.replace(/^\/+|\/+$/g, '') : '';
-				const fullPath = [cleanRemote, cleanSubPath].filter(Boolean).join('/');
+				const fullPath = [cleanRemotePath, cleanSubPath].filter(Boolean).join('/');
 				if (fullPath) {
 					const encoded = encodePathForGraph(fullPath);
 					nextUrl = `/me/drive/special/approot:/${encoded}:/delta`;
@@ -631,9 +634,14 @@ export class OneDriveClient {
 			// Loop always exits via return above; this satisfies TypeScript
 			throw new Error('Unreachable: delta pagination loop exited unexpectedly');
 		} catch (error) {
-			// If the scoped folder does not exist yet, treat as empty so first sync can create it.
-			if (cleanSubPath && !deltaLink && this.isItemNotFoundError(error)) {
-				logger.info(`Delta target '${cleanSubPath}' not found remotely — treating as empty`);
+			// If the scoped target does not exist yet, treat as empty so the first
+			// sync can proceed and create it via upload. This covers both a scoped
+			// subPath (e.g. the config dir) and a scoped vault subfolder in
+			// app-folder mode (remotePath) — the latter is free-typed and may not
+			// exist remotely until the first upload (issue #97 follow-up).
+			if (!deltaLink && this.isItemNotFoundError(error) && (cleanSubPath || cleanRemotePath)) {
+				const target = [cleanRemotePath, cleanSubPath].filter(Boolean).join('/');
+				logger.info(`Delta target '${target}' not found remotely — treating as empty`);
 				return { items: [], deltaLink: '' };
 			}
 

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -2098,7 +2098,7 @@ export class SyncEngine {
 			progress(t('progress.advancingDeltaCursor'));
 			try {
 				const newDelta = await this.oneDriveClient.getDelta(undefined, this.remoteRoot);
-				this.stateManager.setDeltaLink(newDelta.deltaLink);
+				this.stateManager.setDeltaLink(newDelta.deltaLink, true);
 				const shouldSyncObsidianScope =
 					this.shouldSyncPath(`${this.configDir}/community-plugins.json`) ||
 					this.shouldSyncPath(`${this.configDir}/app.json`);

--- a/tests/unit/api/oneDriveClient.test.ts
+++ b/tests/unit/api/oneDriveClient.test.ts
@@ -513,6 +513,24 @@ describe('OneDriveClient', () => {
 			expect(result).toEqual({ items: [], deltaLink: '' });
 		});
 
+		// Issue #97 follow-up: a scoped app-folder subfolder (remotePath, no
+		// subPath) may not exist remotely on first sync — treat as empty, don't
+		// throw and abort the whole sync.
+		it('treats 404 on a scoped remotePath (no subPath) as empty on first sync', async () => {
+			const error = new OneDriveError('Not found', undefined, 404);
+			mockApiGet.mockRejectedValueOnce(error);
+
+			const result = await client.getDelta(undefined, 'vault_a');
+			expect(result).toEqual({ items: [], deltaLink: '' });
+		});
+
+		it('rethrows a 404 for the unscoped app-folder root query', async () => {
+			const error = new OneDriveError('Not found', undefined, 404);
+			mockApiGet.mockRejectedValue(error);
+
+			await expect(client.getDelta()).rejects.toBeInstanceOf(OneDriveError);
+		});
+
 		it('uses root delta for shared-drive when both relativePath and subPath are empty', async () => {
 			client.setRemoteDrive('drive-123', 'item-456', 'Shared', '');
 			mockApiGet.mockResolvedValue({ value: [item1], '@odata.deltaLink': 'delta-1' });


### PR DESCRIPTION
Fixes two regressions found in code review of #101 (both currently on `main` / in the unreleased 1.5.0 draft).

## 1. (High) Fresh app-folder + subfolder users fail their first sync
Scoping the app-folder delta to the vault subfolder made the **main** delta call query `approot:/<subfolder>:/delta`. On a brand-new setup that subfolder doesn't exist remotely yet (remote folders are created lazily during the first upload), so the call returns **404**. The existing "treat as empty" recovery only fired when a `subPath` was passed — the main call passes none — so it rethrew and aborted the whole first sync.

Existing #97 victims are unaffected (their subfolder already exists); this only hit *new* app-folder-with-subfolder setups.

**Fix:** hoist `cleanRemotePath` and broaden the not-found recovery to treat a missing scoped `remotePath` (not just `subPath`) as empty on first sync.

## 2. (Med) Reconcile advances a scoped cursor but doesn't flag it
`syncEngine.ts` reconcile saved the freshly-scoped cursor via `setDeltaLink(link)` (defaults `scoped=false`), so the next normal sync's `retireLegacyUnscopedDeltaLink()` immediately dropped it, forcing a needless full re-enumeration. **Fix:** `setDeltaLink(link, true)`.

## Tests
- 404 on a scoped `remotePath` (no subPath) → empty result (first sync proceeds).
- 404 on the unscoped app-folder **root** query still throws (unchanged).

447 tests pass; build clean.

## ⚠️ Note
The 1.5.0 release is currently a **draft** and contains the High-severity bug above. Recommend holding/re-cutting it until this lands. **Do not merge without your review.**