### PR TITLE
Add bug-fix postmortem skill (5 Whys + hardening) and auto-trigger workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,3 +26,13 @@ cp main.js ~/Documents/JeffBrain-Octo/JeffBrain-Octo/.obsidian/plugins/onedrive-
 ```
 
 Then reload the plugin in Obsidian.
+
+## Postmortems
+
+When a bug-fix PR is merged, `.github/workflows/postmortem.yml` opens a tracking
+issue and assigns the Copilot coding agent to run the postmortem skill at
+`.github/skills/postmortem/SKILL.md`: a **5 Whys** root-cause analysis plus a
+**hardening PR** that prevents the whole bug *class* (types/guards/invariants +
+regression and sibling-case tests). To run one by hand, ask Copilot to
+"run the postmortem skill for PR #N". Never merge the hardening PR automatically.
+

--- a/.github/skills/postmortem/SKILL.md
+++ b/.github/skills/postmortem/SKILL.md
@@ -1,0 +1,118 @@
+# Skill: Bug-Fix Postmortem (5 Whys + Hardening)
+
+## Purpose
+
+Whenever a bug-fix PR is merged, run a structured postmortem that goes beyond
+"the fix works" and asks **why the bug was possible at all**, then make code and
+test changes that make a whole *class* of similar bugs harder to reintroduce.
+
+A fix removes one bug. A good postmortem removes the conditions that let it exist.
+
+## When this runs
+
+- **Automatically:** `.github/workflows/postmortem.yml` triggers on merge of a PR
+  that is a bug fix (has the `bug` label, or has `- [x] Bug fix` checked in the
+  PR's *Type of Change* section). It opens a tracking issue and assigns the
+  Copilot coding agent to follow this skill.
+- **Manually:** Run the Copilot CLI in the repo and ask it to
+  "run the postmortem skill for PR #N". Provide the PR number.
+
+## Inputs you are given
+
+- The merged bug-fix PR number, title, body, and merge commit SHA.
+- The linked issue (if any) that the PR fixed.
+
+## Process — do these steps in order
+
+### 1. Reconstruct what happened
+
+- Read the PR diff: `gh pr diff <N>` and `git show <mergeSha>`.
+- Read the linked/fixing issue and any repro steps or logs.
+- Identify the exact lines the fix changed and the user-visible symptom.
+
+### 2. Find where the bug was introduced
+
+- For each changed hunk, blame it: `git log -S "<distinctive snippet>" --oneline`
+  and `git blame` on the pre-fix lines.
+- Determine whether this was a **regression** (previously-correct behavior broke)
+  or a **latent gap** (never worked; only became observable under new conditions).
+- Record the introducing commit/PR when identifiable.
+
+### 3. Ask the 5 Whys
+
+Write a genuine 5-level causal chain, not five restatements of the symptom.
+Each "why" must answer the previous answer. Example shape:
+
+1. **Why did the bug happen?** — the immediate mechanism in the code.
+2. **Why was that possible?** — the design/assumption that allowed it.
+3. **Why did that assumption hold in the code?** — where it was encoded.
+4. **Why didn't tests catch it?** — the missing test dimension/scenario.
+5. **Why didn't review/process catch it?** — the systemic gap (platform coverage,
+   invariant not documented, type not making illegal states unrepresentable, etc.).
+
+Stop at the first "why" whose answer is genuinely outside the codebase's control.
+
+### 4. Decide hardening actions
+
+From the deepest actionable "why", choose concrete changes that prevent the
+*class* of bug, not just the one instance. Prefer, in order:
+
+1. **Make illegal states unrepresentable** (types, exhaustive switches, invariants).
+2. **Assertions / guards** at the boundary where the bad assumption lived, with a
+   clear log or error when violated.
+3. **Regression + generalization tests** — one test reproducing the original bug,
+   plus tests covering the sibling cases that share the same assumption (e.g. the
+   other platforms, the other change types, the empty/non-empty variants).
+4. **Documentation of the invariant** next to the code that relies on it, so the
+   next editor sees it.
+
+Do **not** refactor unrelated code. Keep changes surgical and reviewable.
+
+### 5. Validate
+
+- `npm run build`
+- `npx vitest run`
+  Both must pass. Any added regression test must fail before your hardening change
+  and pass after it.
+
+### 6. Output — comment **and** hardening PR
+
+- **Comment** the postmortem on the tracking issue using the template below.
+- **Open a hardening PR** (`postmortem/<pr-number>-<slug>` branch) whose description
+  links the tracking issue (`Closes #<issue>`) and summarizes the changes. Follow
+  the repo `pull_request_template.md` and check `Bug fix`.
+- Do **not** merge the PR — leave it for maintainer review.
+
+## Postmortem comment template
+
+```markdown
+## 🔬 Postmortem — PR #<N>: <title>
+
+**Symptom:** <what the user saw>
+**Fix shipped:** <one line: what PR #N changed>
+**Regression?** <Yes/No + introducing commit/PR, or "latent gap since <commit>">
+
+### 5 Whys
+1. **Why?** …
+2. **Why?** …
+3. **Why?** …
+4. **Why?** …
+5. **Why (root)?** …
+
+### How we missed it
+<the specific missing test dimension / coverage gap>
+
+### Hardening (this PR: #<hardening-PR>)
+- <invariant/type/guard added>
+- <regression test + generalized sibling-case tests>
+- <docs of the invariant, if any>
+
+### Follow-ups (optional)
+- <anything out of scope for one PR>
+```
+
+## Guardrails
+
+- Never merge PRs automatically — maintainer review is required.
+- Only run linters/build/tests that already exist in the repo.
+- Keep the hardening PR focused on preventing this bug class; no drive-by rewrites.

--- a/.github/workflows/postmortem.yml
+++ b/.github/workflows/postmortem.yml
@@ -1,0 +1,137 @@
+name: Bug-Fix Postmortem
+
+# On merge of a bug-fix PR, open a tracking issue and assign the Copilot coding
+# agent to run the postmortem skill (.github/skills/postmortem/SKILL.md):
+# a 5-Whys root-cause analysis plus a hardening PR that prevents the bug class.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  postmortem:
+    # Only for merged PRs (not merely closed), and never for postmortem PRs
+    # themselves (avoid infinite loops).
+    if: >-
+      github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.head.ref, 'postmortem/') &&
+      !contains(github.event.pull_request.labels.*.name, 'postmortem')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open postmortem issue and assign Copilot
+        uses: actions/github-script@v7
+        with:
+          # A PAT with Copilot access assigns the coding agent reliably; the
+          # default GITHUB_TOKEN is used as a fallback (assignment may then be
+          # left to a maintainer). Reuses the repo's existing PAT_TOKEN secret.
+          github-token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const labels = (pr.labels || []).map(l => l.name);
+
+            // ---- Qualify: is this a bug fix? ----
+            const hasBugLabel = labels.includes('bug');
+            const bugFixChecked = /-\s*\[x\]\s*Bug fix/i.test(body);
+            if (!hasBugLabel && !bugFixChecked) {
+              core.info(`PR #${pr.number} is not a bug fix (no 'bug' label, Bug fix unchecked). Skipping.`);
+              return;
+            }
+            core.info(`PR #${pr.number} qualifies (bugLabel=${hasBugLabel}, bugFixChecked=${bugFixChecked}).`);
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // ---- Ensure the 'postmortem' label exists ----
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name: 'postmortem' });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner, repo, name: 'postmortem', color: '5319e7',
+                description: 'Automated 5-Whys postmortem for a merged bug fix',
+              });
+            }
+
+            // ---- Find a linked issue this PR fixed (best effort) ----
+            const closesMatch = body.match(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i);
+            const linkedIssue = closesMatch ? closesMatch[1] : null;
+
+            // ---- Create the tracking issue ----
+            const issueBody = [
+              `A bug-fix PR was merged. Run the postmortem skill to find the root cause and harden the system.`,
+              ``,
+              `**Fixing PR:** #${pr.number} — ${pr.title}`,
+              `**Merge commit:** ${pr.merge_commit_sha || '(see PR)'}`,
+              linkedIssue ? `**Original bug issue:** #${linkedIssue}` : `**Original bug issue:** (none linked)`,
+              ``,
+              `---`,
+              ``,
+              `@copilot Please follow the process defined in the repo file`,
+              `\`.github/skills/postmortem/SKILL.md\` for **PR #${pr.number}**:`,
+              ``,
+              `1. Reconstruct the bug from the PR diff and linked issue.`,
+              `2. Blame the introducing commit; classify regression vs. latent gap.`,
+              `3. Write a genuine **5 Whys** causal chain.`,
+              `4. Make **surgical hardening changes** (types/guards/invariants) plus a`,
+              `   regression test and generalized sibling-case tests that prevent this`,
+              `   *class* of bug — not just this instance.`,
+              `5. Validate with \`npm run build\` and \`npx vitest run\`.`,
+              `6. **Post the 5-Whys writeup as a comment on this issue** and **open a`,
+              `   hardening PR** (\`postmortem/${pr.number}-<slug>\` branch) that`,
+              `   \`Closes #<this issue>\`. Do **not** merge it.`,
+              ``,
+              `_Automated by \`.github/workflows/postmortem.yml\`._`,
+            ].join('\n');
+
+            const { data: issue } = await github.rest.issues.create({
+              owner, repo,
+              title: `Postmortem: PR #${pr.number} — ${pr.title}`,
+              body: issueBody,
+              labels: ['postmortem'],
+            });
+            core.info(`Created postmortem issue #${issue.number}.`);
+
+            // ---- Assign the Copilot coding agent via GraphQL ----
+            // REST addAssignees with login "Copilot" silently no-ops; the coding
+            // agent must be assigned with replaceActorsForAssignable using the
+            // copilot-swe-agent bot node id from suggestedActors(CAN_BE_ASSIGNED).
+            let assigned = false;
+            try {
+              const suggested = await github.graphql(`
+                query($owner:String!,$repo:String!){
+                  repository(owner:$owner,name:$repo){
+                    suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:100){
+                      nodes{ login __typename ... on Bot { id } ... on User { id } }
+                    }
+                  }
+                }`, { owner, repo });
+              const bot = suggested.repository.suggestedActors.nodes
+                .find(n => n.login === 'copilot-swe-agent' || n.login.toLowerCase() === 'copilot');
+              if (bot && bot.id) {
+                await github.graphql(`
+                  mutation($assignableId:ID!,$actorIds:[ID!]!){
+                    replaceActorsForAssignable(input:{assignableId:$assignableId, actorIds:$actorIds}){
+                      assignable { ... on Issue { number } }
+                    }
+                  }`, { assignableId: issue.node_id, actorIds: [bot.id] });
+                assigned = true;
+                core.info('Assigned Copilot coding agent to the postmortem issue.');
+              } else {
+                core.warning('Copilot coding agent not available as an assignee for this repo.');
+              }
+            } catch (e) {
+              core.warning(`Could not assign Copilot automatically: ${e.message}`);
+            }
+
+            // ---- Link back from the merged PR ----
+            const note = assigned
+              ? `🔬 Opened postmortem #${issue.number} and assigned the Copilot coding agent to run a 5-Whys analysis and propose hardening changes.`
+              : `🔬 Opened postmortem #${issue.number}. Assign it to the Copilot coding agent (or run the postmortem skill manually) to generate the 5-Whys analysis and hardening PR.`;
+            await github.rest.issues.createComment({
+              owner, repo, issue_number: pr.number, body: note,
+            });


### PR DESCRIPTION
Adds an automated postmortem process.

## What
- **`.github/skills/postmortem/SKILL.md`** — defines the process: reconstruct the bug, blame the introducing commit (regression vs. latent gap), write a genuine **5 Whys** chain, make **surgical hardening changes** (types/guards/invariants + regression and sibling-case tests), validate, then **comment the writeup and open a hardening PR**. Usable manually via Copilot CLI too.
- **`.github/workflows/postmortem.yml`** — on merge of a bug-fix PR (`bug` label OR `- [x] Bug fix` checked), opens a tracking issue and assigns the Copilot coding agent to follow the skill. Skips postmortem PRs to avoid loops.
- **`.github/copilot-instructions.md`** — documents the skill.

## Mechanism
Reuses the proven `suggestedActors(CAN_BE_ASSIGNED)` -> `replaceActorsForAssignable` GraphQL flow (same as the automation repo's `copilot-autofix.yml`). Verified `copilot-swe-agent` is assignable in this repo. Uses the existing `PAT_TOKEN` secret, falling back to `GITHUB_TOKEN`.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Does not merge the resulting hardening PRs — maintainer review required.