### PR TITLE
fix: harden sync reliability edge cases

### DIFF
--- a/src/api/chunkUpload.ts
+++ b/src/api/chunkUpload.ts
@@ -6,11 +6,32 @@
  */
 
 import { requestUrl } from 'obsidian';
-import { OneDriveUploadSession, OneDriveItem, OneDriveError } from '../types';
+import { OneDriveUploadSession, OneDriveItem, OneDriveError, RateLimitError } from '../types';
 import { SYNC_CONFIG, GRAPH_API_ENDPOINT } from '../constants';
 import { logger } from '../utils/logger';
 import { retryWithBackoff } from '../utils/retry';
+import { parseRetryAfterHeader } from '../utils/errors';
 import { OneDriveClient } from './oneDriveClient';
+
+// How many times a large-file upload may consult the session's
+// nextExpectedRanges to resume after a chunk fails its retries.
+const MAX_SESSION_RESUMES = 3;
+
+/**
+ * Build the error for a failed upload HTTP response. 429s become
+ * RateLimitError carrying the server's Retry-After hint (Graph sends it
+ * in the header, not the body); everything else keeps its status code so
+ * retryWithBackoff can classify it.
+ */
+function uploadHttpError(
+	prefix: string,
+	response: { status: number; headers: Record<string, string> }
+): OneDriveError {
+	if (response.status === 429) {
+		return new RateLimitError(`${prefix}: HTTP 429`, parseRetryAfterHeader(response.headers));
+	}
+	return new OneDriveError(`${prefix}: HTTP ${response.status}`, undefined, response.status);
+}
 
 /**
  * Calculate optimal chunk size based on file size
@@ -83,11 +104,7 @@ export class ChunkUploader {
 				});
 
 				if (response.status < 200 || response.status >= 300) {
-					throw new OneDriveError(
-						`Failed to upload file: HTTP ${response.status}`,
-						undefined,
-						response.status
-					);
+					throw uploadHttpError('Failed to upload file', response);
 				}
 
 				return response.json as OneDriveItem;
@@ -116,27 +133,50 @@ export class ChunkUploader {
 		// Step 1: Create upload session
 		const session = await this.createUploadSession(filePath);
 
-		// Step 2: Upload chunks
-		let uploadedBytes = 0;
-		const chunks = Math.ceil(fileSize / chunkSize);
+		// Step 2: Upload chunks sequentially (Graph requires in-order ranges).
+		// If a chunk fails after its retries, consult the session's
+		// nextExpectedRanges to resume — already-accepted bytes are kept
+		// server-side and don't need re-uploading.
+		const totalChunks = Math.ceil(fileSize / chunkSize);
+		let position = 0;
+		let resumesLeft = MAX_SESSION_RESUMES;
 		let finalItem: OneDriveItem | null = null;
 
-		for (let i = 0; i < chunks; i++) {
-			const start = i * chunkSize;
-			const end = Math.min(start + chunkSize, fileSize);
-			const chunk = content.slice(start, end);
+		while (position < fileSize) {
+			const end = Math.min(position + chunkSize, fileSize);
+			const chunk = content.slice(position, end);
 
-			const result = await this.uploadChunk(session.uploadUrl, chunk, start, end - 1, fileSize);
+			let result: OneDriveItem | null;
+			try {
+				result = await this.uploadChunk(session.uploadUrl, chunk, position, end - 1, fileSize);
+			} catch (error) {
+				if (resumesLeft <= 0) {
+					throw error;
+				}
+				resumesLeft--;
+				const resumePosition = await this.getResumePosition(session.uploadUrl);
+				if (resumePosition === undefined || resumePosition >= fileSize) {
+					throw error;
+				}
+				logger.warn(
+					`Chunk upload interrupted at byte ${position}; session resume from byte ${resumePosition}`
+				);
+				position = resumePosition;
+				continue;
+			}
+
 			if (result) {
 				finalItem = result;
 			}
 
-			uploadedBytes = end;
+			position = end;
 			if (onProgress) {
-				onProgress(uploadedBytes, fileSize);
+				onProgress(position, fileSize);
 			}
 
-			logger.debug(`Uploaded chunk ${i + 1}/${chunks} (${uploadedBytes}/${fileSize} bytes)`);
+			logger.debug(
+				`Uploaded chunk ${Math.ceil(position / chunkSize)}/${totalChunks} (${position}/${fileSize} bytes)`
+			);
 		}
 
 		// The last chunk (200/201) returns the completed item directly.
@@ -200,7 +240,7 @@ export class ChunkUploader {
 
 				// 202 = chunk accepted, 201/200 = upload complete
 				if (![200, 201, 202].includes(response.status)) {
-					throw new OneDriveError(`Failed to upload chunk: HTTP ${response.status}`);
+					throw uploadHttpError('Failed to upload chunk', response);
 				}
 
 				// Final chunk — server returns the completed item
@@ -219,6 +259,33 @@ export class ChunkUploader {
 	}
 
 	/**
+	 * Query the upload session for the next byte offset the server expects.
+	 * Used to resume a chunked upload after a failed chunk. Returns undefined
+	 * when the session status can't be read (caller rethrows the chunk error).
+	 */
+	private async getResumePosition(uploadUrl: string): Promise<number | undefined> {
+		try {
+			const response = await requestUrl({
+				url: uploadUrl,
+				method: 'GET',
+				throw: false,
+			});
+			if (response.status !== 200) {
+				return undefined;
+			}
+			const ranges = (response.json as { nextExpectedRanges?: string[] }).nextExpectedRanges;
+			const firstRange = ranges?.[0];
+			if (!firstRange) {
+				return undefined;
+			}
+			const start = Number(firstRange.split('-')[0]);
+			return Number.isFinite(start) ? start : undefined;
+		} catch {
+			return undefined;
+		}
+	}
+
+	/**
 	 * Get final item after upload completes
 	 */
 	private async getFinalItem(uploadUrl: string): Promise<OneDriveItem> {
@@ -226,6 +293,7 @@ export class ChunkUploader {
 			const response = await requestUrl({
 				url: uploadUrl,
 				method: 'GET',
+				throw: false,
 			});
 
 			if (response.status !== 200) {

--- a/src/api/oneDriveClient.ts
+++ b/src/api/oneDriveClient.ts
@@ -43,10 +43,10 @@ import { ONEDRIVE_PATHS } from '../constants';
 
 interface GraphCollectionResponse<T> {
 	value: T[];
+	'@odata.nextLink'?: string;
 }
 
 interface GraphDeltaApiResponse<T> extends GraphCollectionResponse<T> {
-	'@odata.nextLink'?: string;
 	'@odata.deltaLink'?: string;
 }
 
@@ -179,6 +179,23 @@ export class OneDriveClient {
 		return retryWithBackoff<T>(() => this.client.api(endpoint).get() as Promise<T>);
 	}
 
+	/**
+	 * Fetch every page of a Graph collection endpoint by following
+	 * @odata.nextLink. Graph caps /children responses at ~200 items per page,
+	 * so a single GET silently truncates large folders.
+	 */
+	private async getAllPages(endpoint: string): Promise<OneDriveItem[]> {
+		const items: OneDriveItem[] = [];
+		let nextUrl: string | undefined = endpoint;
+		while (nextUrl) {
+			const response: GraphCollectionResponse<OneDriveItem> =
+				await this.getGraph<GraphCollectionResponse<OneDriveItem>>(nextUrl);
+			items.push(...response.value);
+			nextUrl = response['@odata.nextLink'];
+		}
+		return items;
+	}
+
 	private async postGraph<T>(endpoint: string, body: unknown): Promise<T> {
 		return retryWithBackoff<T>(() => this.client.api(endpoint).post(body) as Promise<T>);
 	}
@@ -207,17 +224,6 @@ export class OneDriveClient {
 			throw new OneDriveError(
 				`Failed to resolve shared folder: ${error instanceof Error ? error.message : 'Unknown error'}`
 			);
-		}
-	}
-
-	/**
-	 * @deprecated Use buildEndpoint() instead. Kept for backward compat during migration.
-	 */
-	getDriveEndpoint(path: string): string {
-		if (this.accessMode === OneDriveAccessMode.APP_FOLDER) {
-			return `/me/drive/special/approot:/${path}`;
-		} else {
-			return `/me/drive/root:/${path}`;
 		}
 	}
 
@@ -287,9 +293,7 @@ export class OneDriveClient {
 
 		try {
 			const apiPath = this.buildEndpoint(folderPath, 'children');
-			const response = await this.getGraph<GraphCollectionResponse<OneDriveItem>>(apiPath);
-
-			return response.value;
+			return await this.getAllPages(apiPath);
 		} catch (error) {
 			logger.error(`Failed to list folder ${folderPath}:`, error);
 			throw new OneDriveError(
@@ -334,8 +338,7 @@ export class OneDriveClient {
 				}
 			}
 
-			const response = await this.getGraph<GraphCollectionResponse<OneDriveItem>>(apiPath);
-			const items = response.value;
+			const items = await this.getAllPages(apiPath);
 
 			// Return only folders (including shared/mounted shortcuts)
 			return items.filter((item) => item.folder || item.remoteItem?.folder);
@@ -365,9 +368,9 @@ export class OneDriveClient {
 				apiPath = `/me/drive/special/approot:/${encoded}:/children`;
 			}
 
-			const response = await this.getGraph<GraphCollectionResponse<OneDriveItem>>(apiPath);
+			const items = await this.getAllPages(apiPath);
 			// Return only folders
-			return response.value.filter((item) => item.folder);
+			return items.filter((item) => item.folder);
 		} catch (error) {
 			logger.error(`Failed to list App Folder subfolders at ${folderPath}:`, error);
 			throw new OneDriveError(
@@ -414,8 +417,13 @@ export class OneDriveClient {
 				'@microsoft.graph.conflictBehavior': 'fail',
 			});
 		} catch (error) {
-			// Ignore if folder already exists
-			if (error instanceof Error && error.message.includes('nameAlreadyExists')) {
+			// Ignore if folder already exists — check the Graph error code first,
+			// with a message-text fallback for errors that don't carry one
+			const graphCode = (error as { code?: unknown })?.code;
+			if (
+				graphCode === 'nameAlreadyExists' ||
+				(error instanceof Error && error.message.includes('nameAlreadyExists'))
+			) {
 				logger.debug(`Folder ${folderName} already exists`);
 				return this.getItemByPath(folderPath ? `${folderPath}/${folderName}` : folderName);
 			}

--- a/src/auth/authProvider.ts
+++ b/src/auth/authProvider.ts
@@ -48,6 +48,11 @@ import { AuthenticationError } from '../types';
  * Implements Microsoft Graph's AuthenticationProvider interface
  */
 export class OneDriveAuthProvider implements AuthenticationProvider {
+	// In-flight refresh, shared across concurrent getAccessToken() callers.
+	// Microsoft rotates refresh tokens, so parallel refreshes can invalidate
+	// each other's tokens — only one refresh may run at a time.
+	private refreshPromise: Promise<void> | null = null;
+
 	constructor(
 		private tokenStorage: TokenStorage,
 		private deviceCodeClient: DeviceCodeFlowClient,
@@ -67,8 +72,15 @@ export class OneDriveAuthProvider implements AuthenticationProvider {
 
 		// Check if token needs refresh (with 2-minute buffer)
 		if (this.tokenStorage.isAccessTokenExpired(SYNC_CONFIG.TOKEN_REFRESH_BUFFER_MS)) {
-			logger.debug('Access token expired or expiring soon, refreshing...');
-			await this.refreshAccessToken();
+			if (!this.refreshPromise) {
+				logger.debug('Access token expired or expiring soon, refreshing...');
+				this.refreshPromise = this.refreshAccessToken().finally(() => {
+					this.refreshPromise = null;
+				});
+			} else {
+				logger.debug('Refresh already in flight, awaiting it');
+			}
+			await this.refreshPromise;
 		}
 
 		const accessToken = this.tokenStorage.getAccessToken();

--- a/src/auth/deviceCodeFlow.ts
+++ b/src/auth/deviceCodeFlow.ts
@@ -124,6 +124,11 @@ export class DeviceCodeFlowClient {
 		this.cancelled = false;
 		const startTime = Date.now();
 		const expiresAt = startTime + expiresIn * 1000;
+		// Abort after this many back-to-back network failures instead of
+		// silently polling until the device code expires (a persistent server
+		// error would otherwise look like a multi-minute hang to the user).
+		const maxConsecutiveNetworkErrors = 5;
+		let consecutiveNetworkErrors = 0;
 
 		while (Date.now() < expiresAt) {
 			if (this.cancelled) {
@@ -152,6 +157,9 @@ export class DeviceCodeFlowClient {
 					return data;
 				}
 
+				// Got a response from the server — reset the network error streak
+				consecutiveNetworkErrors = 0;
+
 				// Handle error responses (including 400s from Obsidian's requestUrl)
 				const errorData = response.json as unknown as OAuthErrorResponse;
 				const errorCode = errorData.error;
@@ -178,6 +186,13 @@ export class DeviceCodeFlowClient {
 					throw error;
 				}
 				// Network or temporary error - log but continue polling
+				consecutiveNetworkErrors++;
+				if (consecutiveNetworkErrors >= maxConsecutiveNetworkErrors) {
+					logger.error('Aborting token polling after repeated network errors:', error);
+					throw new AuthenticationError(
+						'Repeated network errors during authentication. Please check your connection and try again.'
+					);
+				}
 				logger.warn('Network error during token polling, will retry:', error);
 				if (onPending) onPending();
 			}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -35,8 +35,6 @@ export const SYNC_CONFIG = {
 	EVENT_THROTTLE_MS: 3000,
 	// Token refresh buffer (milliseconds before expiry)
 	TOKEN_REFRESH_BUFFER_MS: 120000, // 2 minutes
-	// Default chunk size for large file uploads
-	DEFAULT_CHUNK_SIZE: 6815744, // 6.5 MB (proven size from remotely-save)
 	// Minimum chunk size for OneDrive API
 	MIN_CHUNK_SIZE: 327680, // 320 KB
 	// Maximum chunk size for OneDrive API
@@ -53,11 +51,4 @@ export const ONEDRIVE_PATHS = {
 	APP_FOLDER: '/Apps/ObsidianOneDrive',
 	// Special value for app folder API endpoint
 	APP_ROOT: 'approot',
-};
-
-// Plugin metadata
-export const PLUGIN_INFO = {
-	NAME: 'OneDrive Sync',
-	ID: 'onedrive-sync',
-	VERSION: '0.1.0',
 };

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -216,6 +216,8 @@ export const de = {
 			automaticInterval: {
 				name: 'Automatisches Synchronisierungsintervall',
 				desc: 'Auf 0 setzen für nur manuelle Synchronisierung (empfohlen für Akkulaufzeit)',
+				currentValue: 'Aktuell: alle {{minutes}} Minuten.',
+				currentDisabled: 'Aktuell: nur manuelle Synchronisierung.',
 				resetTooltip: 'Auf Standard zurücksetzen',
 			},
 			startupDelay: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -216,6 +216,8 @@ export const en = {
 			automaticInterval: {
 				name: 'Automatic sync interval',
 				desc: 'Set to 0 for manual sync only (recommended for battery life)',
+				currentValue: 'Currently: every {{minutes}} minutes.',
+				currentDisabled: 'Currently: manual sync only.',
 				resetTooltip: 'Reset to default',
 			},
 			syncOnFileChange: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -216,6 +216,8 @@ export const es = {
 			automaticInterval: {
 				name: 'Intervalo de sincronización automática',
 				desc: 'Establecer en 0 para sincronización manual solamente (recomendado para duración de batería)',
+				currentValue: 'Actual: cada {{minutes}} minutos.',
+				currentDisabled: 'Actual: solo sincronización manual.',
 				resetTooltip: 'Restablecer a predeterminado',
 			},
 			startupDelay: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -216,6 +216,8 @@ export const fr = {
 			automaticInterval: {
 				name: 'Intervalle de synchronisation automatique',
 				desc: 'Définir à 0 pour synchronisation manuelle uniquement (recommandé pour l\'autonomie de la batterie)',
+				currentValue: 'Actuellement : toutes les {{minutes}} minutes.',
+				currentDisabled: 'Actuellement : synchronisation manuelle uniquement.',
 				resetTooltip: 'Réinitialiser par défaut',
 			},
 			startupDelay: {

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -216,6 +216,8 @@ export const it = {
 			automaticInterval: {
 				name: 'Intervallo sincronizzazione automatica',
 				desc: 'Imposta a 0 per sincronizzazione manuale (consigliato per durata batteria)',
+				currentValue: 'Attuale: ogni {{minutes}} minuti.',
+				currentDisabled: 'Attuale: solo sincronizzazione manuale.',
 				resetTooltip: 'Ripristina predefinito',
 			},
 			startupDelay: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -216,6 +216,8 @@ export const ja = {
 			automaticInterval: {
 				name: '自動同期間隔',
 				desc: '手動同期のみにするには0に設定（バッテリー寿命のため推奨）',
+				currentValue: '現在：{{minutes}}分ごとに同期。',
+				currentDisabled: '現在：手動同期のみ。',
 				resetTooltip: 'デフォルトにリセット',
 			},
 			startupDelay: {

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -216,6 +216,8 @@ export const pt = {
 			automaticInterval: {
 				name: 'Intervalo de sincronização automática',
 				desc: 'Defina como 0 para sincronização manual apenas (recomendado para duração da bateria)',
+				currentValue: 'Atual: a cada {{minutes}} minutos.',
+				currentDisabled: 'Atual: apenas sincronização manual.',
 				resetTooltip: 'Redefinir para padrão',
 			},
 			startupDelay: {

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -215,6 +215,8 @@ export const zhCn = {
 			automaticInterval: {
 				name: '自动同步间隔',
 				desc: '设为 0 时仅手动同步，推荐用于节省电量。',
+				currentValue: '当前：每 {{minutes}} 分钟同步一次。',
+				currentDisabled: '当前：仅手动同步。',
 				resetTooltip: '恢复默认值',
 			},
 			syncOnFileChange: {

--- a/src/sync/eventManager.ts
+++ b/src/sync/eventManager.ts
@@ -22,6 +22,10 @@ export class EventManager {
 	private throttleTimer?: number;
 	private syncTimer?: number;
 	private isSyncing = false;
+	// Set when a vault change arrives while a sync is running, so a follow-up
+	// sync gets scheduled once the current one finishes (instead of the change
+	// sitting in the dirty queue until the next unrelated trigger).
+	private syncRequestedDuringSync = false;
 	private dirtyFiles: Map<string, LocalChange> = new Map();
 	// Paths we wrote during sync — events for these are our own writes, not user edits
 	private ownWritePaths: Set<string> = new Set();
@@ -298,7 +302,10 @@ export class EventManager {
 	 */
 	private scheduleSync(): void {
 		if (!this.syncOnFileChange) return;
-		if (this.isSyncing) return;
+		if (this.isSyncing) {
+			this.syncRequestedDuringSync = true;
+			return;
+		}
 
 		if (this.throttleTimer !== undefined) {
 			timerApi.clearTimeout(this.throttleTimer);
@@ -373,6 +380,14 @@ export class EventManager {
 			logger.error('Error during sync:', error);
 		} finally {
 			this.isSyncing = false;
+			// Changes that arrived mid-sync couldn't schedule — do it now so
+			// they don't wait for the next unrelated trigger. Only vault-event
+			// callers set the flag, so failed operations re-queued by the sync
+			// engine can't create a retry loop here.
+			if (this.syncRequestedDuringSync) {
+				this.syncRequestedDuringSync = false;
+				this.scheduleSync();
+			}
 		}
 	}
 

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -77,6 +77,7 @@ import {
 } from '../types';
 import { logger } from '../utils/logger';
 import { isDeferrableError } from '../utils/errors';
+import { sha1HexUpper } from '../utils/contentHash';
 import {
 	normalizePath,
 	toOneDrivePath,
@@ -275,7 +276,7 @@ export class SyncEngine {
 				await this.fetchAndFilterRemoteChanges(ignoreMatchers, progress);
 
 			// Phase 3: Diff local vs remote to produce upload/download/conflict ops
-			const operations = this.planOperations(localChanges, remoteChanges, isFirstSync);
+			const operations = await this.planOperations(localChanges, remoteChanges, isFirstSync);
 
 			// On first sync the dirty queue is empty, so walk the vault and add
 			// uploads for any local-only files not already covered by the delta
@@ -493,8 +494,10 @@ export class SyncEngine {
 
 		// Config files inside .obsidian/ don't fire vault events (they
 		// aren't TFile instances). Detect changes by comparing their
-		// current mtime/size against tracked sync state.
-		const configChanges = await this.detectConfigFileChanges(ignoreMatchers);
+		// current mtime/size against tracked sync state. Pass the dirty
+		// snapshot we already took so both phases see the same queue.
+		const dirtyPaths = new Set(allLocalChanges.map((change) => change.path));
+		const configChanges = await this.detectConfigFileChanges(ignoreMatchers, dirtyPaths);
 		localChanges.push(...configChanges);
 
 		logger.info(
@@ -569,8 +572,14 @@ export class SyncEngine {
 	 * Detect local changes to .obsidian/ config files by comparing their
 	 * current mtime/size against the last-synced state. Returns synthetic
 	 * LocalChange entries for any files that changed or were deleted.
+	 *
+	 * @param dirtyPaths Paths already queued by vault events (snapshot taken
+	 *   by the caller) — checked as a Set so large config sets stay O(1) per path.
 	 */
-	private async detectConfigFileChanges(ignoreMatchers: RegExp[]): Promise<LocalChange[]> {
+	private async detectConfigFileChanges(
+		ignoreMatchers: RegExp[],
+		dirtyPaths: Set<string>
+	): Promise<LocalChange[]> {
 		const adapter = this.app.vault.adapter;
 		const changes: LocalChange[] = [];
 
@@ -588,7 +597,7 @@ export class SyncEngine {
 			if (!this.shouldSyncPath(path)) continue;
 			if (this.shouldIgnorePath(path, ignoreMatchers)) continue;
 			// Skip paths already queued by vault events
-			if (this.eventManager.getDirtyFiles().some((d) => d.path === path)) continue;
+			if (dirtyPaths.has(path)) continue;
 			// Skip paths we just wrote during a previous download
 			if (this.eventManager.isOwnWrite(path)) continue;
 
@@ -653,7 +662,7 @@ export class SyncEngine {
 			if (checkedPaths.has(path)) continue;
 			if (!this.shouldSyncPath(path)) continue;
 			if (this.shouldIgnorePath(path, ignoreMatchers)) continue;
-			if (this.eventManager.getDirtyFiles().some((d) => d.path === path)) continue;
+			if (dirtyPaths.has(path)) continue;
 
 			try {
 				const stat = await adapter.stat(path);
@@ -713,11 +722,14 @@ export class SyncEngine {
 			this.shouldSyncPath(`${this.configDir}/app.json`);
 		const isFirstSync = this.stateManager.isFirstSync();
 		logger.info(`Delta query: isFirstSync=${isFirstSync}, hasDeltaLink=${!!deltaLink}`);
-		const deltaResponse = await this.oneDriveClient.getDelta(deltaLink, this.remoteRoot);
 		const obsidianDeltaLink = this.stateManager.getObsidianDeltaLink();
-		const obsidianDeltaResponse = shouldSyncObsidianScope
-			? await this.oneDriveClient.getDelta(obsidianDeltaLink, this.remoteRoot, this.configDir)
-			: undefined;
+		// The two delta streams are independent — fetch them in parallel
+		const [deltaResponse, obsidianDeltaResponse] = await Promise.all([
+			this.oneDriveClient.getDelta(deltaLink, this.remoteRoot),
+			shouldSyncObsidianScope
+				? this.oneDriveClient.getDelta(obsidianDeltaLink, this.remoteRoot, this.configDir)
+				: Promise.resolve(undefined),
+		]);
 
 		progress(t('progress.planning'));
 
@@ -1023,11 +1035,11 @@ export class SyncEngine {
 	/**
 	 * Plan sync operations from local changes and remote delta
 	 */
-	private planOperations(
+	private async planOperations(
 		localChanges: LocalChange[],
 		remoteChanges: OneDriveItem[],
 		isFirstSync: boolean
-	): SyncOperation[] {
+	): Promise<SyncOperation[]> {
 		const operations: SyncOperation[] = [];
 
 		// Build a map of remote changes by vault path
@@ -1217,11 +1229,17 @@ export class SyncEngine {
 				const file = this.app.vault.getAbstractFileByPath(vaultPath);
 				if (file instanceof TFile) {
 					if (file.stat.size === (item.size || 0)) {
-						// Same size — likely identical, store state and skip
-						this.stateManager.setFileState(vaultPath, this.itemToFileState(item));
-						continue;
+						// Same size — verify content via hash when the remote item
+						// carries one (same-size-different-content would otherwise
+						// silently never sync). Falls back to trusting the size
+						// match when no hash is available.
+						const matches = await this.localContentMatchesRemote(vaultPath, item);
+						if (matches !== false) {
+							this.stateManager.setFileState(vaultPath, this.itemToFileState(item));
+							continue;
+						}
 					}
-					// File exists but different size — download remote version
+					// File exists but content differs — download remote version
 					operations.push({
 						path: vaultPath,
 						direction: SyncDirection.DOWNLOAD,
@@ -1250,6 +1268,32 @@ export class SyncEngine {
 		}
 
 		return operations;
+	}
+
+	/**
+	 * Verify a local file's content against the remote item's sha1Hash.
+	 * Returns true/false when a comparison was possible, or undefined when
+	 * it wasn't (no remote hash, unreadable file, or no WebCrypto) so the
+	 * caller can fall back to the size heuristic.
+	 */
+	private async localContentMatchesRemote(
+		path: string,
+		item: OneDriveItem
+	): Promise<boolean | undefined> {
+		const remoteSha1 = item.file?.hashes?.sha1Hash;
+		if (!remoteSha1) return undefined;
+		try {
+			const content = await this.app.vault.adapter.readBinary(path);
+			const localSha1 = await sha1HexUpper(content);
+			if (!localSha1) return undefined;
+			const matches = localSha1 === remoteSha1.toUpperCase();
+			if (!matches) {
+				logger.info(`Same-size content mismatch detected via sha1 for ${path}`);
+			}
+			return matches;
+		} catch {
+			return undefined;
+		}
 	}
 
 	/**
@@ -2047,7 +2091,13 @@ export class SyncEngine {
 					});
 				} else {
 					const remoteSize = item.size || 0;
-					if (local.size !== remoteSize) {
+					// Same-size files are verified via sha1 when the remote item
+					// carries a hash; without one we assume same content.
+					const contentMatches =
+						local.size === remoteSize
+							? await this.localContentMatchesRemote(path, item)
+							: false;
+					if (contentMatches === false) {
 						sizeMismatch.push(path);
 						operations.push({
 							path,
@@ -2055,7 +2105,7 @@ export class SyncEngine {
 							remoteState: this.itemToFileState(item),
 						});
 					} else {
-						// Same size — assume same content, just refresh tracked state.
+						// Content matches (or no hash to compare) — refresh tracked state.
 						this.stateManager.setFileState(path, this.itemToFileState(item));
 					}
 				}
@@ -2116,17 +2166,18 @@ export class SyncEngine {
 			// 8. Advance delta cursors so the next normal sync starts clean.
 			progress(t('progress.advancingDeltaCursor'));
 			try {
-				const newDelta = await this.oneDriveClient.getDelta(undefined, this.remoteRoot);
-				this.stateManager.setDeltaLink(newDelta.deltaLink, true);
 				const shouldSyncObsidianScope =
 					this.shouldSyncPath(`${this.configDir}/community-plugins.json`) ||
 					this.shouldSyncPath(`${this.configDir}/app.json`);
-				if (shouldSyncObsidianScope) {
-					const newObs = await this.oneDriveClient.getDelta(
-						undefined,
-						this.remoteRoot,
-						this.configDir
-					);
+				// The two delta streams are independent — fetch them in parallel
+				const [newDelta, newObs] = await Promise.all([
+					this.oneDriveClient.getDelta(undefined, this.remoteRoot),
+					shouldSyncObsidianScope
+						? this.oneDriveClient.getDelta(undefined, this.remoteRoot, this.configDir)
+						: Promise.resolve(undefined),
+				]);
+				this.stateManager.setDeltaLink(newDelta.deltaLink, true);
+				if (newObs) {
 					this.stateManager.setObsidianDeltaLink(newObs.deltaLink);
 				}
 			} catch (error) {

--- a/src/sync/syncState.ts
+++ b/src/sync/syncState.ts
@@ -10,6 +10,11 @@ import { logger } from '../utils/logger';
  */
 export class SyncStateManager {
 	private state: SyncState;
+	// Reverse indexes kept in sync with fileStates/folderStates so hot-path
+	// lookups (delta delete resolution, folder discovery) stay O(1) instead
+	// of scanning every tracked entry.
+	private oneDriveIdToPath: Map<string, string> = new Map();
+	private folderPathToId: Map<string, string> = new Map();
 
 	constructor() {
 		this.state = {
@@ -17,6 +22,20 @@ export class SyncStateManager {
 			fileStates: new Map(),
 			folderStates: new Map(),
 		};
+	}
+
+	/**
+	 * Rebuild both reverse indexes from the primary maps.
+	 */
+	private rebuildIndexes(): void {
+		this.oneDriveIdToPath.clear();
+		this.folderPathToId.clear();
+		for (const [path, state] of this.state.fileStates) {
+			if (state.oneDriveId) this.oneDriveIdToPath.set(state.oneDriveId, path);
+		}
+		for (const [id, path] of this.state.folderStates) {
+			this.folderPathToId.set(path, id);
+		}
 	}
 
 	/**
@@ -36,6 +55,7 @@ export class SyncStateManager {
 				fileStates: new Map(),
 				folderStates: new Map(),
 			};
+			this.rebuildIndexes();
 			return;
 		}
 
@@ -47,6 +67,7 @@ export class SyncStateManager {
 			deltaLinkScoped: data.deltaLinkScoped,
 			obsidianDeltaLink: data.obsidianDeltaLink,
 		};
+		this.rebuildIndexes();
 
 		logger.debug('Sync state loaded', {
 			lastSyncTime: new Date(data.lastSyncTime).toISOString(),
@@ -157,13 +178,28 @@ export class SyncStateManager {
 	 * Set file state
 	 */
 	setFileState(path: string, state: FileState): void {
+		const previous = this.state.fileStates.get(path);
+		if (
+			previous?.oneDriveId &&
+			previous.oneDriveId !== state.oneDriveId &&
+			this.oneDriveIdToPath.get(previous.oneDriveId) === path
+		) {
+			this.oneDriveIdToPath.delete(previous.oneDriveId);
+		}
 		this.state.fileStates.set(path, state);
+		if (state.oneDriveId) {
+			this.oneDriveIdToPath.set(state.oneDriveId, path);
+		}
 	}
 
 	/**
 	 * Remove file state
 	 */
 	removeFileState(path: string): void {
+		const previous = this.state.fileStates.get(path);
+		if (previous?.oneDriveId && this.oneDriveIdToPath.get(previous.oneDriveId) === path) {
+			this.oneDriveIdToPath.delete(previous.oneDriveId);
+		}
 		this.state.fileStates.delete(path);
 	}
 
@@ -183,10 +219,7 @@ export class SyncStateManager {
 	 */
 	getPathByOneDriveId(oneDriveId: string): string | undefined {
 		if (!oneDriveId) return undefined;
-		for (const [path, state] of this.state.fileStates) {
-			if (state.oneDriveId === oneDriveId) return path;
-		}
-		return undefined;
+		return this.oneDriveIdToPath.get(oneDriveId);
 	}
 
 	/**
@@ -197,7 +230,16 @@ export class SyncStateManager {
 	 */
 	setFolderState(oneDriveId: string, vaultPath: string): void {
 		if (!oneDriveId) return;
+		const previousPath = this.state.folderStates.get(oneDriveId);
+		if (
+			previousPath &&
+			previousPath !== vaultPath &&
+			this.folderPathToId.get(previousPath) === oneDriveId
+		) {
+			this.folderPathToId.delete(previousPath);
+		}
 		this.state.folderStates.set(oneDriveId, vaultPath);
+		this.folderPathToId.set(vaultPath, oneDriveId);
 	}
 
 	getFolderPathById(oneDriveId: string): string | undefined {
@@ -206,6 +248,10 @@ export class SyncStateManager {
 	}
 
 	removeFolderState(oneDriveId: string): void {
+		const path = this.state.folderStates.get(oneDriveId);
+		if (path !== undefined && this.folderPathToId.get(path) === oneDriveId) {
+			this.folderPathToId.delete(path);
+		}
 		this.state.folderStates.delete(oneDriveId);
 	}
 
@@ -213,22 +259,17 @@ export class SyncStateManager {
 	 * Reverse-resolve a vault folder path to its OneDrive item id.
 	 */
 	getFolderIdByPath(vaultPath: string): string | undefined {
-		for (const [id, path] of this.state.folderStates) {
-			if (path === vaultPath) return id;
-		}
-		return undefined;
+		return this.folderPathToId.get(vaultPath);
 	}
 
 	/**
 	 * Remove a folder state entry by its vault path.
 	 */
 	removeFolderStateByPath(vaultPath: string): void {
-		for (const [id, path] of this.state.folderStates) {
-			if (path === vaultPath) {
-				this.state.folderStates.delete(id);
-				return;
-			}
-		}
+		const id = this.folderPathToId.get(vaultPath);
+		if (id === undefined) return;
+		this.folderPathToId.delete(vaultPath);
+		this.state.folderStates.delete(id);
 	}
 
 	/**
@@ -284,12 +325,14 @@ export class SyncStateManager {
 			fileStates: new Map(),
 			folderStates: new Map(),
 		};
+		this.rebuildIndexes();
 		logger.debug('Sync state cleared');
 	}
 
 	/** Wipe all tracked file states but keep folder states and delta link. */
 	clearFileStates(): void {
 		this.state.fileStates.clear();
+		this.oneDriveIdToPath.clear();
 		logger.debug('Tracked file states cleared');
 	}
 }

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -36,7 +36,7 @@ interface OneDrivePlugin {
 	resetSyncToken(): Promise<void>;
 	reconcileFromCloud(): Promise<void>;
 	authenticate(): Promise<void>;
-	disconnect(): void;
+	disconnect(): Promise<void>;
 	triggerManualSync(): Promise<void>;
 	listFoldersForPicker(
 		path: string,
@@ -298,7 +298,7 @@ export class OneDriveSettingTab extends PluginSettingTab {
 			// Disconnect button
 				statusSetting.addButton((button) =>
 					button.setButtonText(t('settings.auth.connectionStatus.disconnect')).onClick(async () => {
-						this.plugin.disconnect();
+						await this.plugin.disconnect();
 						this.renderSettings();
 					})
 				);
@@ -424,16 +424,28 @@ export class OneDriveSettingTab extends PluginSettingTab {
 
 		const { configDir } = this.app.vault;
 
-		// Sync interval
-		new Setting(containerEl)
+		// Sync interval — show the current value in the description (and via
+		// the slider's dynamic tooltip) since sliders give no feedback on
+		// mobile otherwise.
+		const intervalDesc = (minutes: number): string => {
+			const current =
+				minutes > 0
+					? t('settings.sync.automaticInterval.currentValue', { minutes })
+					: t('settings.sync.automaticInterval.currentDisabled');
+			return `${t('settings.sync.automaticInterval.desc')} ${current}`;
+		};
+		const intervalSetting = new Setting(containerEl)
 			.setName(t('settings.sync.automaticInterval.name'))
-			.setDesc(t('settings.sync.automaticInterval.desc'))
+			.setDesc(intervalDesc(this.plugin.settings.syncInterval));
+		intervalSetting
 			.addSlider((slider) =>
 				slider
 					.setLimits(0, 60, 5)
 					.setValue(this.plugin.settings.syncInterval)
+					.setDynamicTooltip()
 					.onChange(async (value) => {
 						this.plugin.settings.syncInterval = value;
+						intervalSetting.setDesc(intervalDesc(value));
 						await this.plugin.saveSettings();
 					})
 			)

--- a/src/utils/contentHash.ts
+++ b/src/utils/contentHash.ts
@@ -1,0 +1,24 @@
+/**
+ * Content hashing for local↔remote comparison.
+ *
+ * OneDrive Personal returns a `sha1Hash` in the driveItem hashes facet
+ * (uppercase hex). Computing the same hash locally lets us verify that
+ * a same-size local file really has the same content as the remote copy,
+ * instead of relying on the size heuristic alone.
+ */
+
+/**
+ * Compute the SHA-1 of a buffer as an uppercase hex string (the format
+ * OneDrive uses for `sha1Hash`). Returns undefined when WebCrypto is
+ * unavailable so callers can fall back to the size heuristic.
+ */
+export async function sha1HexUpper(data: ArrayBuffer): Promise<string | undefined> {
+	if (typeof crypto === 'undefined' || !crypto.subtle) {
+		return undefined;
+	}
+	const digest = await crypto.subtle.digest('SHA-1', data);
+	return Array.from(new Uint8Array(digest))
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('')
+		.toUpperCase();
+}

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -100,9 +100,30 @@ export function handleAuthErrors(
 }
 
 /**
- * Parse error from HTTP response
+ * Parse a Retry-After response header value into seconds.
+ * Graph sends the throttling wait hint in this header, not the JSON body.
  */
-export function parseHttpError(status: number, body: string): Error {
+export function parseRetryAfterHeader(
+	headers: Record<string, string> | undefined
+): number | undefined {
+	if (!headers) return undefined;
+	const raw = headers['retry-after'] ?? headers['Retry-After'];
+	if (!raw) return undefined;
+	const seconds = Number(raw);
+	return Number.isFinite(seconds) && seconds > 0 ? seconds : undefined;
+}
+
+/**
+ * Parse error from HTTP response.
+ * Pass the response headers when available so 429s pick up the server's
+ * Retry-After hint instead of the fixed fallback.
+ */
+export function parseHttpError(
+	status: number,
+	body: string,
+	headers?: Record<string, string>
+): Error {
+	const headerRetryAfter = parseRetryAfterHeader(headers);
 	try {
 		const json = JSON.parse(body) as ParsedHttpErrorBody;
 		const errorCode = json.error || json.error_description || 'unknown_error';
@@ -111,12 +132,15 @@ export function parseHttpError(status: number, body: string): Error {
 		if (status === 401) {
 			return new AuthenticationError(errorMessage, errorCode);
 		} else if (status === 429) {
-			const retryAfter = json.retry_after || 60;
+			const retryAfter = headerRetryAfter || json.retry_after || 60;
 			return new RateLimitError(errorMessage, retryAfter);
 		} else {
 			return new OneDriveError(errorMessage, errorCode, status);
 		}
 	} catch {
+		if (status === 429) {
+			return new RateLimitError(`HTTP 429: ${body}`, headerRetryAfter || 60);
+		}
 		// Failed to parse JSON, return generic error
 		return new OneDriveError(`HTTP ${status}: ${body}`, undefined, status);
 	}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -70,15 +70,22 @@ export async function retryWithBackoff<T>(
 			// Cap delay at maxDelay
 			delay = Math.min(delay, opts.maxDelay);
 
+			// Add jitter so parallel operations don't retry in lock-step and
+			// re-thunder the API. Server-instructed delays (Retry-After) only
+			// jitter upward so we never retry earlier than instructed.
+			const jitteredDelay = customDelay
+				? delay + Math.round(Math.random() * 0.25 * delay)
+				: Math.round(delay * (0.75 + Math.random() * 0.5));
+
 			logger.debug(
-				`Attempt ${attempt}/${opts.maxAttempts} failed, retrying in ${delay}ms`,
+				`Attempt ${attempt}/${opts.maxAttempts} failed, retrying in ${jitteredDelay}ms`,
 				lastError.message
 			);
 
-			opts.onRetry(attempt, delay, lastError);
+			opts.onRetry(attempt, jitteredDelay, lastError);
 
 			// Wait before retrying
-			await sleep(delay);
+			await sleep(jitteredDelay);
 
 			// Exponential backoff for next attempt
 			delay *= opts.backoffMultiplier;

--- a/tests/unit/sync/eventManager.test.ts
+++ b/tests/unit/sync/eventManager.test.ts
@@ -520,7 +520,7 @@ describe('EventManager', () => {
 			expect(onSyncTriggered).toHaveBeenCalledTimes(1);
 		});
 
-		it('does not schedule a new sync while one is already running', async () => {
+		it('defers a sync requested during a running sync until it completes', async () => {
 			const deferred = createDeferred();
 			onSyncTriggered = vi.fn().mockImplementation(() => deferred.promise);
 			eventManager = new EventManager(mockApp as any, onSyncTriggered, stateManager);
@@ -534,13 +534,15 @@ describe('EventManager', () => {
 			eventCallbacks.modify(makeTFile('second.md', 100));
 			await vi.advanceTimersByTimeAsync(500);
 
+			// No overlapping sync while one is still running
 			expect(onSyncTriggered).toHaveBeenCalledTimes(1);
 
 			deferred.resolve();
 			await Promise.resolve();
 			await vi.advanceTimersByTimeAsync(200);
 
-			expect(onSyncTriggered).toHaveBeenCalledTimes(1);
+			// The change that arrived mid-sync schedules a follow-up sync
+			expect(onSyncTriggered).toHaveBeenCalledTimes(2);
 		});
 
 		it('still tracks dirty files but does not schedule sync when syncOnFileChange is disabled', async () => {


### PR DESCRIPTION
- verify same-size files against remote sha1Hash so content edits that keep the size still sync
- resume chunked uploads via nextExpectedRanges and honor 429 Retry-After with jittered retries
- follow @odata.nextLink when listing folders to avoid silent truncation past ~200 items
- share one in-flight token refresh and abort device-code polling after repeated network errors
- defer syncs requested mid-sync, fetch both delta streams in parallel, index state for O(1) lookups
- show current sync interval in settings (all locales) and drop unused constants

## Description

<!-- Brief description of changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [ ] Tests pass (`npm test`)
- [ ] Build succeeds (`npm run build`)
- [ ] Manually tested in Obsidian

## Checklist

- [ ] Code follows existing style
- [ ] Self-reviewed the changes
- [ ] Updated documentation if needed
