### PR TITLE
docs: explain how to install pre-releases via BRAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Sync your Obsidian vault with **OneDrive Personal** accounts. Zero-config, mobil
 
 1. Install [BRAT](https://github.com/TfTHacker/obsidian42-brat) from Community Plugins
 2. BRAT settings → **Add Beta Plugin** → `JeffSteinbok/obsidian-onedrive`
+3. To receive pre-release builds, enable **"Enable beta versions"** in the Add Beta Plugin dialog (BRAT installs only the latest full release otherwise). You can toggle this later per-plugin in BRAT's settings.
 
 ### Manual
 


### PR DESCRIPTION
The README's **Via BRAT** section only covered adding the plugin — which installs the latest *full* release and skips pre-releases. This adds the step to enable **"Enable beta versions"** so users can actually receive the pre-release builds published by `prerelease.yml`.

Docs-only change.

## Type of Change
- [ ] Bug fix
- [x] Documentation