### PR TITLE
fix(sync): stop runaway duplicate copies on create-duplicate conflicts (#128)

### DIFF
--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -1177,12 +1177,33 @@ export class SyncEngine {
 						remoteSize: remoteItem.size || 0,
 					};
 					const resolution = this.conflictResolver.resolveConflict(conflictInfo);
-					operations.push({
-						path: resolution.newPath || change.path,
-						direction: resolution.direction,
-						localState: knownState,
-						remoteState: this.itemToFileState(remoteItem),
-					});
+					const remoteState = this.itemToFileState(remoteItem);
+					if (resolution.newPath) {
+						// CREATE_DUPLICATE: preserve the remote version under a new
+						// dated name, then converge the base path by uploading the
+						// local version. Without this converging upload the base
+						// file keeps its stale tracked hash, so it is re-detected as
+						// a conflict on every subsequent sync and a fresh dated copy
+						// is spawned each cycle — the runaway duplication in #128.
+						operations.push({
+							path: resolution.newPath,
+							direction: SyncDirection.DOWNLOAD,
+							remoteState,
+						});
+						operations.push({
+							path: change.path,
+							direction: SyncDirection.UPLOAD,
+							localState: knownState,
+							remoteState,
+						});
+					} else {
+						operations.push({
+							path: change.path,
+							direction: resolution.direction,
+							localState: knownState,
+							remoteState,
+						});
+					}
 				} else {
 					// No known state, upload local
 					operations.push({ path: change.path, direction: SyncDirection.UPLOAD });

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -673,6 +673,77 @@ describe('SyncEngine', () => {
 			expect.stringContaining(' (conflict '),
 			expect.any(ArrayBuffer)
 		);
+		// The base file must be converged (local uploaded) so the conflict
+		// clears — otherwise it re-fires every sync and spawns a new copy
+		// each cycle (issue #128).
+		expect(mockFileOps.uploadFile).toHaveBeenCalledWith(
+			expect.stringContaining('test.md'),
+			expect.anything()
+		);
+	});
+
+	it('does not spawn a new duplicate on the next sync after a create-duplicate conflict (issue #128)', async () => {
+		stateManager.setLastSyncTime(Date.now());
+		stateManager.setFileState('notes/test.md', {
+			path: 'notes/test.md',
+			localMtime: 50,
+			remoteHash: 'known-hash',
+			size: 50,
+			remoteModifiedTime: 100,
+			oneDriveId: 'remote-id',
+		});
+		mockEventManager.getDirtyFiles.mockReturnValue([
+			{ path: 'notes/test.md', type: LocalChangeType.MODIFY },
+		]);
+		mockClient.getDelta.mockResolvedValue({
+			items: [makeRemoteFile('notes/test.md', { id: 'remote-id' })],
+			deltaLink: 'delta-link-2',
+		});
+		mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+			path === 'notes/test.md'
+				? makeTFile('notes/test.md', 100, Date.now())
+				: makeTFile(path, 10, Date.now())
+		);
+
+		const duplicateEngine = new SyncEngine(
+			mockApp as any,
+			mockFileOps as any,
+			mockClient as any,
+			stateManager,
+			new ConflictResolver(ConflictResolutionStrategy.CREATE_DUPLICATE),
+			mockEventManager as any,
+			'.obsidian',
+			{ remoteRoot: '/remote/root' }
+		);
+
+		await duplicateEngine.performSync();
+		const copiesAfterFirst = mockApp.vault.adapter.writeBinary.mock.calls.filter(
+			(call: unknown[]) => typeof call[0] === 'string' && call[0].includes(' (conflict ')
+		).length;
+		expect(copiesAfterFirst).toBe(1);
+
+		// Second sync: the converging upload set the base file's tracked hash to
+		// the uploaded value ('hash123'); the next delta reports that same hash,
+		// so it is not a real conflict and no new copy is made.
+		mockApp.vault.adapter.writeBinary.mockClear();
+		mockEventManager.getDirtyFiles.mockReturnValue([
+			{ path: 'notes/test.md', type: LocalChangeType.MODIFY },
+		]);
+		mockClient.getDelta.mockResolvedValue({
+			items: [
+				makeRemoteFile('notes/test.md', {
+					id: 'remote-id',
+					file: { mimeType: 'text/plain', hashes: { quickXorHash: 'hash123' } },
+				}),
+			],
+			deltaLink: 'delta-link-3',
+		});
+
+		await duplicateEngine.performSync();
+		const newCopies = mockApp.vault.adapter.writeBinary.mock.calls.filter(
+			(call: unknown[]) => typeof call[0] === 'string' && call[0].includes(' (conflict ')
+		).length;
+		expect(newCopies).toBe(0);
 	});
 
 	it('re-uploads local changes when the remote file was deleted', async () => {


### PR DESCRIPTION
Fixes the runaway file duplication in #128.

## Root cause
With **Conflict resolution = "Create duplicate"**, a real conflict is resolved by downloading the remote version into a new dated file (`note (conflict 2026-07-27 12-30-45).md`). But the engine never updated the **base** file's tracked state, so `note.md` kept its stale `remoteHash` and was re-detected as a conflict on **every** subsequent sync — producing a fresh dated copy each cycle.

Because "sync on file change" fires a debounced sync every few seconds while you're actively editing (independent of the "0" interval, which only governs the periodic timer), this turned into a new copy roughly every few seconds — matching the report ("syncing every second", "duplicated several times"). Default `last-write-wins` was unaffected because it updates the same-path state and converges.

## Fix
On a create-duplicate conflict, also **upload the local version to the base path**, converging its tracked hash with the remote:
- remote version → preserved as the dated copy (unchanged behavior),
- local version → wins the canonical path,
- conflict **clears after one cycle** instead of regenerating forever.

`last-write-wins` and manual-conflict behavior are unchanged.

## Tests
- New regression test: after a create-duplicate conflict, the **next sync creates no additional copy**.
- Extended the existing create-duplicate test to assert the converging upload.
- Full suite green (492 tests), lint + build clean.

## Not covered here
If the base file's converging upload itself fails (e.g. OneDrive returns **423 Locked** — the "deferred" symptom), convergence is delayed until a later successful sync. That deferred-lock angle is being confirmed via the debug log requested on the issue; this PR removes the unbounded-duplication engine regardless.

## Type of Change
- [x] Bug fix
