### PR TITLE
ci(postmortem): guard against stuck/empty/junk postmortem PRs

### DIFF
--- a/.github/workflows/postmortem-guard.yml
+++ b/.github/workflows/postmortem-guard.yml
@@ -1,0 +1,104 @@
+name: Postmortem PR Guard
+
+# Postmortem hardening PRs (opened by the Copilot coding agent via
+# postmortem.yml) have repeatedly gotten "stuck": left titled "[WIP]", pushed
+# with an empty branch (no committed work), or missing the 5-Whys writeup — all
+# while showing a green build, so nothing signalled that they were undeliverable.
+#
+# This guard turns each of those failure modes into a hard, visible red check so
+# a stuck postmortem PR can never be silently merged (or silently ignored):
+#   1. title still contains "[WIP]"
+#   2. PR is still a draft
+#   3. the branch has NO file changes (agent never committed its work)
+#   4. the body is missing a non-empty `postmortem-writeup` block
+#   5. the body has no `Fixes/Closes #<issue>` tracking reference
+#
+# Uses `pull_request_target` (like postmortem-publish.yml) so it is NOT subject
+# to the manual "approve workflows" gate applied to Copilot-authored PRs, and so
+# it runs the trusted workflow definition from the base branch. It only READS PR
+# metadata via the API and never checks out PR head code.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review, converted_to_draft]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Postmortem PR number to validate'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  guard:
+    # Only postmortem hardening PRs (agent branches or the documented convention).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.pull_request.head.ref, 'postmortem/') ||
+      startsWith(github.event.pull_request.head.ref, 'copilot/postmortem')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate postmortem PR is deliverable
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            // ---- Resolve the PR (event payload or dispatch input) ----
+            let pr;
+            if (context.eventName === 'workflow_dispatch') {
+              const num = parseInt('${{ inputs.pr_number }}', 10);
+              ({ data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: num }));
+            } else {
+              pr = context.payload.pull_request;
+            }
+            const body = pr.body || '';
+            const title = pr.title || '';
+            const problems = [];
+
+            // 1) WIP title
+            if (/\[wip\]/i.test(title)) {
+              problems.push('Title still contains `[WIP]` — clear it once the work is ready.');
+            }
+
+            // 2) Draft PR
+            if (pr.draft) {
+              problems.push('PR is still a draft — mark it "Ready for review".');
+            }
+
+            // 3) Empty branch (the agent never committed its work)
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            if (files.length === 0) {
+              problems.push('Branch has **no file changes** — the hardening work was never committed/pushed.');
+            }
+
+            // 4) Non-empty 5-Whys writeup between the markers
+            const m = body.match(
+              /<!--\s*postmortem-writeup:start\s*-->\s*([\s\S]*?)\s*<!--\s*postmortem-writeup:end\s*-->/i
+            );
+            const writeup = m ? m[1].trim() : '';
+            if (!m) {
+              problems.push('Missing `<!-- postmortem-writeup:start -->` / `:end` markers in the PR body.');
+            } else if (writeup.length < 80 || !/why/i.test(writeup)) {
+              problems.push('Writeup between the markers is empty or too thin — include a real 5-Whys analysis.');
+            }
+
+            // 5) Tracking issue reference
+            if (!/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i.test(body)) {
+              problems.push('No `Fixes #<issue>` / `Closes #<issue>` reference to the postmortem tracking issue.');
+            }
+
+            if (problems.length > 0) {
+              core.setFailed(
+                `Postmortem PR #${pr.number} is not deliverable:\n` +
+                problems.map(p => `  - ${p}`).join('\n')
+              );
+              return;
+            }
+            core.info(`Postmortem PR #${pr.number} passes all guard checks.`);

--- a/.github/workflows/postmortem-publish.yml
+++ b/.github/workflows/postmortem-publish.yml
@@ -68,6 +68,14 @@ jobs:
               core.warning(`PR #${pr.number} writeup markers are empty. Skipping.`);
               return;
             }
+            // Guard against mirroring junk (an earlier bug published a comment
+            // that literally read "` and >    `"). Require a substantive 5-Whys.
+            if (writeup.length < 80 || !/why/i.test(writeup)) {
+              core.warning(
+                `PR #${pr.number} writeup is too thin (len=${writeup.length}, has "why"=${/why/i.test(writeup)}). Skipping to avoid publishing junk.`
+              );
+              return;
+            }
 
             // ---- Find the tracking issue this PR closes ----
             const closesMatch = body.match(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/i);

--- a/.github/workflows/postmortem.yml
+++ b/.github/workflows/postmortem.yml
@@ -121,6 +121,11 @@ jobs:
               `   \`postmortem-publish.yml\` workflow mirrors it here as a comment`,
               `   automatically. Do **not** comment here yourself and do **not** merge.`,
               ``,
+              `   The \`postmortem-guard.yml\` check enforces this: the PR must have`,
+              `   committed changes, a non-\`[WIP]\` ready-for-review title, a`,
+              `   non-empty 5-Whys writeup between the markers, and this \`Closes #\``,
+              `   reference — or the check fails.`,
+              ``,
               `_Automated by \`.github/workflows/postmortem.yml\`._`,
             ].join('\n');
 


### PR DESCRIPTION
Prevents postmortem hardening PRs from silently getting "stuck" — the failure we just hit on #133 (and previously #124/#127).

## What kept happening
The Copilot coding agent's postmortem PRs repeatedly:
- were left titled **`[WIP]`** / as drafts,
- had an **empty branch** — the agent claimed it built + tested a refactor but never committed/pushed a single file (#133 had only an empty "Initial plan" commit),
- shipped a **missing/garbled 5-Whys**, which `postmortem-publish.yml` then mirrored to the tracking issue as junk (the #132 comment literally read `` ` and >    ` ``).

All of this while `build-and-test` stayed **green** (the branch == main), so nothing flagged the PR as undeliverable.

## Guardrails
- **New `postmortem-guard.yml`** — a check on `postmortem/*` and `copilot/postmortem*` PRs that **fails** when any of these are true:
  1. title still contains `[WIP]`
  2. PR is still a draft
  3. branch has **no file changes** (work never committed)
  4. writeup markers missing, or the writeup is empty/too thin (<80 chars or no "Why")
  5. no `Fixes/Closes #<issue>` tracking reference

  Turns every silent failure mode into a visible red X, so a stuck postmortem can't be blindly merged or ignored.
- **Hardened `postmortem-publish.yml`** — refuses to mirror a writeup shorter than 80 chars or lacking a "Why", so junk can never reach the tracking issue again.
- **`postmortem.yml`** — tells the agent up front that the guard enforces a committed, ready (non-`[WIP]`), fully-written PR.

Both new checks use `pull_request_target` (read-only PR metadata, no PR-code checkout) so they aren't blocked by the Copilot-actor workflow-approval gate — same pattern/rationale as the existing publish workflow.

> Recommend adding **Postmortem PR Guard** to the branch-protection required checks so it actually blocks merges.

## Type of Change
- [x] CI / tooling (no runtime code change)
