### PR TITLE
docs: postmortem pointer (guard verification)

### DIFF
--- a/docs/POSTMORTEM.md
+++ b/docs/POSTMORTEM.md
@@ -118,3 +118,5 @@ gh workflow run postmortem.yml -f pr_number=<PR>
 
 Or, in the Copilot CLI inside the repo, ask it to *"run the postmortem skill for
 PR #N"* and follow [`SKILL.md`](../.github/skills/postmortem/SKILL.md).
+
+<!-- postmortem automation docs: see .github/workflows/postmortem-*.yml -->


### PR DESCRIPTION
Trivial docs pointer; also verifies the always-run guard reports success on normal PRs.