### PR TITLE
fix: don't recreate phantom old-path file on rename (#138)

### DIFF
--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -1098,6 +1098,28 @@ export class SyncEngine {
 				logger.info(`Processing rename: ${change.oldPath} → ${change.path}`);
 				const oldState = this.stateManager.getFileState(change.oldPath);
 
+				// The delta may still report the pre-rename item at the OLD path —
+				// an echo of our own earlier upload that carries the SAME OneDrive
+				// ID we're about to move/re-upload. It isn't matched by any local
+				// change (the local change is keyed to the NEW path), so the remote
+				// pass below would plan a download and recreate a phantom file
+				// linked to the same remote item. Deleting that phantom then deletes
+				// the renamed file from OneDrive too (issue #138). Drop the stale
+				// echo from the remote worklist when the IDs match.
+				const staleOldRemote = remoteByPath.get(change.oldPath);
+				if (
+					staleOldRemote &&
+					!staleOldRemote.deleted &&
+					oldState?.oneDriveId &&
+					staleOldRemote.id === oldState.oneDriveId
+				) {
+					logger.debug(
+						`Rename: dropping stale remote echo of ${change.oldPath} ` +
+						`(same OneDrive ID ${oldState.oneDriveId})`
+					);
+					remoteByPath.delete(change.oldPath);
+				}
+
 				if (this.useAtomicMoves && oldState?.oneDriveId) {
 					// Use atomic move via OneDrive PATCH API — more efficient (no re-upload)
 					// and avoids duplicate files if something goes wrong

--- a/tests/unit/sync/syncEngine.test.ts
+++ b/tests/unit/sync/syncEngine.test.ts
@@ -318,6 +318,42 @@ describe('SyncEngine', () => {
 		expect(stateManager.getFileState('new.md')).toBeDefined();
 	});
 
+	it('does not re-download the old path when the delta echoes the pre-rename item (issue #138)', async () => {
+		// Repro: a freshly-created "Untitled.md" was uploaded on a prior sync.
+		// The user renames it before the next sync. That sync sees both a local
+		// RENAME (old.md → new.md) AND a delta that still reports the OLD path as
+		// changed — an echo of our own upload carrying the SAME OneDrive ID.
+		// The old path must NOT be pulled back down as a phantom file linked to
+		// the same remote item.
+		stateManager.setLastSyncTime(Date.now());
+		stateManager.setFileState('old.md', {
+			path: 'old.md',
+			localMtime: 1,
+			remoteHash: 'old-hash',
+			size: 10,
+			remoteModifiedTime: 2,
+			oneDriveId: 'shared-remote-id',
+		});
+		mockEventManager.getDirtyFiles.mockReturnValue([
+			{ path: 'new.md', type: LocalChangeType.RENAME, oldPath: 'old.md' },
+		]);
+		// Delta still reports old.md as a live change, sharing the moved item's ID.
+		mockClient.getDelta.mockResolvedValue({
+			items: [makeRemoteFile('old.md', { id: 'shared-remote-id' })],
+			deltaLink: 'delta-link-echo',
+		});
+		mockApp.vault.getAbstractFileByPath.mockReturnValue(makeTFile('new.md', 10, Date.now()));
+
+		await syncEngine.performSync();
+
+		// Atomic move should still happen for the rename...
+		expect(mockFileOps.moveFile).toHaveBeenCalledWith('shared-remote-id', '/remote/root/new.md');
+		// ...but the stale echo of the old path must NOT be downloaded.
+		expect(mockFileOps.downloadFile).not.toHaveBeenCalled();
+		expect(mockApp.vault.adapter.writeBinary).not.toHaveBeenCalled();
+		expect(stateManager.getFileState('old.md')).toBeUndefined();
+	});
+
 	it('downloads remote changes', async () => {
 		stateManager.setLastSyncTime(Date.now());
 		const downloadedFile = makeTFile('notes/remote.md', 10, Date.now());


### PR DESCRIPTION
Fixes #138.

## Problem
When you create a new note and rename it *after* OneDrive-Sync has already synced the `Untitled.md`, a phantom `Untitled.md` appears in the vault secretly linked to the renamed file (`Banana.md`). Deleting the phantom then deletes the real file from OneDrive too.

## Root cause
In `planOperations` (`src/sync/syncEngine.ts`), the rename sync sees two things:
- a **local** `RENAME` `Untitled.md → Banana.md`
- a **remote** delta that *still* reports `Untitled.md` as changed — an echo of our own earlier upload, carrying the **same OneDrive ID**.

The rename branch removed only the **new** path (`Banana.md`) from the `remoteByPath` worklist. The stale echo keyed under the **old** path (`Untitled.md`) survived, so the remote pass planned a `download Untitled.md`, recreating it in the vault tracked with the *same OneDrive ID* as `Banana.md`. Two vault files → one remote item → deleting either deletes both.

## Fix
When handling a `RENAME`, also drop the old path from `remoteByPath` when the stale remote item there shares the OneDrive ID being moved/re-uploaded. Applies to both the atomic-move and legacy delete+upload branches.

## Testing
- Added a regression test (`issue #138`) that reproduces the stale-echo delta and asserts no phantom download occurs. Verified it **fails without** the fix and **passes with** it.
- `npm run build` passes.
- Full suite green except one pre-existing, date-dependent failure in `logManager.test.ts` (fails on `main` too, unrelated).