### PR TITLE
Show the OneDrive app folder path in settings

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -207,7 +207,7 @@ export const de = {
 			connectFirst: 'Erst mit OneDrive verbinden, dann einen Synchronisierungsordner auswählen.',
 			vaultSubfolder: 'Tresor-Unterordner',
 			vaultSubfolderDesc: 'Aktuell: {{path}}. Verwenden Sie einen Unterordner, um diesen Tresor von anderen zu isolieren.',
-			appFolderRoot: '(App-Ordner-Stamm)',
+			appFolderRoot: '/Apps/ObsidianOneDrive/ (App-Ordner-Stamm)',
 			appFolderLabel: 'App-Ordner',
 			useAppFolderRoot: 'App-Ordner-Stamm verwenden',
 		},

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -207,7 +207,7 @@ export const en = {
 			connectFirst: 'Connect to OneDrive first, then select a sync folder.',
 			vaultSubfolder: 'Vault subfolder',
 			vaultSubfolderDesc: 'Current: {{path}}. Use a subfolder to isolate this vault from others.',
-			appFolderRoot: '(app folder root)',
+			appFolderRoot: '/Apps/ObsidianOneDrive/ (app folder root)',
 			appFolderLabel: 'App Folder',
 			useAppFolderRoot: 'Use app folder root',
 		},

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -207,7 +207,7 @@ export const es = {
 			connectFirst: 'Conecta a OneDrive primero, luego selecciona una carpeta de sincronización.',
 			vaultSubfolder: 'Subcarpeta de bóveda',
 			vaultSubfolderDesc: 'Actual: {{path}}. Usa una subcarpeta para aislar esta bóveda de otras.',
-			appFolderRoot: '(raíz de carpeta de aplicación)',
+			appFolderRoot: '/Apps/ObsidianOneDrive/ (raíz de carpeta de aplicación)',
 			appFolderLabel: 'Carpeta de aplicación',
 			useAppFolderRoot: 'Usar raíz de carpeta de aplicación',
 		},

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -207,7 +207,7 @@ export const fr = {
 			connectFirst: 'Connectez-vous d\'abord à OneDrive, puis sélectionnez un dossier de synchronisation.',
 			vaultSubfolder: 'Sous-dossier du coffre',
 			vaultSubfolderDesc: 'Actuel: {{path}}. Utilisez un sous-dossier pour isoler ce coffre des autres.',
-			appFolderRoot: '(racine du dossier d\'application)',
+			appFolderRoot: '/Apps/ObsidianOneDrive/ (racine du dossier d\'application)',
 			appFolderLabel: 'Dossier d\'application',
 			useAppFolderRoot: 'Utiliser la racine du dossier d\'application',
 		},

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -207,7 +207,7 @@ export const it = {
 			connectFirst: 'Connetti prima a OneDrive, poi seleziona una cartella di sincronizzazione.',
 			vaultSubfolder: 'Sottocartella vault',
 			vaultSubfolderDesc: 'Attuale: {{path}}. Usa una sottocartella per isolare questo vault da altri.',
-			appFolderRoot: '(root cartella app)',
+			appFolderRoot: '/Apps/ObsidianOneDrive/ (root cartella app)',
 			appFolderLabel: 'Cartella app',
 			useAppFolderRoot: 'Usa root cartella app',
 		},

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -207,7 +207,7 @@ export const ja = {
 			connectFirst: '先にOneDriveに接続してから、同期フォルダを選択してください。',
 			vaultSubfolder: '保管庫サブフォルダ',
 			vaultSubfolderDesc: '現在: {{path}}。サブフォルダを使用してこの保管庫を他から分離します。',
-			appFolderRoot: '（アプリフォルダルート）',
+			appFolderRoot: '/Apps/ObsidianOneDrive/（アプリフォルダルート）',
 			appFolderLabel: 'アプリフォルダ',
 			useAppFolderRoot: 'アプリフォルダルートを使用',
 		},

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -207,7 +207,7 @@ export const pt = {
 			connectFirst: 'Conecte ao OneDrive primeiro, depois selecione uma pasta de sincronização.',
 			vaultSubfolder: 'Subpasta do cofre',
 			vaultSubfolderDesc: 'Atual: {{path}}. Use uma subpasta para isolar este cofre de outros.',
-			appFolderRoot: '(raiz da pasta do aplicativo)',
+			appFolderRoot: '/Apps/ObsidianOneDrive/ (raiz da pasta do aplicativo)',
 			appFolderLabel: 'Pasta do aplicativo',
 			useAppFolderRoot: 'Usar raiz da pasta do aplicativo',
 		},

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -206,7 +206,7 @@ export const zhCn = {
 			connectFirst: '请先连接 OneDrive，再选择同步文件夹。',
 			vaultSubfolder: '仓库子文件夹',
 			vaultSubfolderDesc: '当前：{{path}}。使用子文件夹将此仓库与其他仓库隔离。',
-			appFolderRoot: '（应用文件夹根目录）',
+			appFolderRoot: '/Apps/ObsidianOneDrive/（应用文件夹根目录）',
 			appFolderLabel: '应用文件夹',
 			useAppFolderRoot: '使用应用文件夹根目录',
 		},


### PR DESCRIPTION
## Summary

- show `/Apps/ObsidianOneDrive/` whenever the app-folder root is displayed in settings
- update the label consistently across all eight supported locales
- keep the change limited to user-facing copy

## Validation

- `npm run build`

Fixes #140