### PR TITLE
Onboard obsidian-onedrive to public Puppets

### DIFF
--- a/.github/puppets/config.json
+++ b/.github/puppets/config.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "approvalActors": [
+    "JeffSteinbok",
+    "jeffsteinbok-openclaw"
+  ],
+  "maxNewIssues": 1,
+  "maxInFlight": 2,
+  "conflictRetries": 2,
+  "reviewRetries": 2,
+  "copilotModel": "auto",
+  "enableCuration": true,
+  "staleHours": 72,
+  "ignoreLabels": [
+    "postmortem"
+  ]
+}

--- a/.github/puppets/implementation.md
+++ b/.github/puppets/implementation.md
@@ -1,0 +1,8 @@
+# Obsidian OneDrive implementation guidance
+
+- Follow `.github/copilot-instructions.md` and repository-specific instruction files.
+- Keep changes scoped to the approved issue.
+- Validate with `npm run build` and `npx vitest run`.
+- Do not process issues labeled `postmortem`; they are owned by the repository's dedicated
+  postmortem workflows and `.github/skills/postmortem/SKILL.md`.
+- Never merge automatically.

--- a/.github/workflows/postmortem.yml
+++ b/.github/workflows/postmortem.yml
@@ -79,14 +79,25 @@ jobs:
               return;
             }
 
-            // ---- Ensure the 'postmortem' label exists ----
-            try {
-              await github.rest.issues.getLabel({ owner, repo, name: 'postmortem' });
-            } catch {
-              await github.rest.issues.createLabel({
-                owner, repo, name: 'postmortem', color: '5319e7',
+            // ---- Ensure process labels exist ----
+            const processLabels = [
+              {
+                name: 'postmortem',
+                color: '5319e7',
                 description: 'Automated 5-Whys postmortem for a merged bug fix',
-              });
+              },
+              {
+                name: 'puppets:no-auto',
+                color: '000000',
+                description: 'Hard opt-out: Puppets automation must never touch this item.',
+              },
+            ];
+            for (const label of processLabels) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+              } catch {
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              }
             }
 
             // ---- Find a linked issue this PR fixed (best effort) ----
@@ -133,7 +144,7 @@ jobs:
               owner, repo,
               title: `Postmortem: PR #${pr.number} — ${pr.title}`,
               body: issueBody,
-              labels: ['postmortem'],
+              labels: ['postmortem', 'puppets:no-auto'],
             });
             core.info(`Created postmortem issue #${issue.number}.`);
 

--- a/.github/workflows/puppets.yml
+++ b/.github/workflows/puppets.yml
@@ -1,0 +1,32 @@
+name: Puppets
+
+on:
+  schedule:
+    - cron: "10 16 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report intended mutations without applying them
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: puppets-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+  copilot-requests: write
+
+jobs:
+  reconcile:
+    uses: JeffSteinbok/puppets/.github/workflows/reconcile.yml@aae92ec6413f723b428703a0d24b3a8544f9a5f8
+    with:
+      dry_run: ${{ inputs.dry_run || false }}
+      caller_workflow: puppets.yml
+    secrets:
+      token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Summary

- add a lightweight repository-owned Puppets caller pinned to the public framework commit
- add trusted local configuration and implementation guidance
- preserve the existing postmortem process by excluding the postmortem label and applying puppets:no-auto to new tracking issues

## Validation

- resolved the caller configuration against the public framework locally
- framework configuration and approval tests pass

Framework: https://github.com/JeffSteinbok/puppets/commit/aae92ec6413f723b428703a0d24b3a8544f9a5f8