### PR TITLE
Route postmortems through Puppets profiles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,9 +30,9 @@ Then reload the plugin in Obsidian.
 ## Postmortems
 
 When a bug-fix PR is merged, `.github/workflows/postmortem.yml` opens a tracking
-issue and assigns the Copilot coding agent to run the postmortem skill at
+issue. After a trusted maintainer applies `puppets:approved`, the Puppets
+postmortem profile assigns the coding agent to run
 `.github/skills/postmortem/SKILL.md`: a **5 Whys** root-cause analysis plus a
 **hardening PR** that prevents the whole bug *class* (types/guards/invariants +
 regression and sibling-case tests). To run one by hand, ask Copilot to
 "run the postmortem skill for PR #N". Never merge the hardening PR automatically.
-

--- a/.github/skills/postmortem/SKILL.md
+++ b/.github/skills/postmortem/SKILL.md
@@ -12,8 +12,9 @@ A fix removes one bug. A good postmortem removes the conditions that let it exis
 
 - **Automatically:** `.github/workflows/postmortem.yml` triggers on merge of a PR
   that is a bug fix (has the `bug` label, or has `- [x] Bug fix` checked in the
-  PR's *Type of Change* section). It opens a tracking issue and assigns the
-  Copilot coding agent to follow this skill.
+  PR's *Type of Change* section). It opens a tracking issue. After a trusted
+  maintainer applies `puppets:approved`, the repository's Puppets postmortem
+  profile assigns the Copilot coding agent to follow this skill.
 - **Manually:** Run the Copilot CLI in the repo and ask it to
   "run the postmortem skill for PR #N". Provide the PR number.
 

--- a/.github/workflows/postmortem.yml
+++ b/.github/workflows/postmortem.yml
@@ -1,8 +1,7 @@
 name: Bug-Fix Postmortem
 
-# When a bug-fix PR is merged, open a tracking issue and assign the Copilot
-# coding agent to run the postmortem skill (.github/skills/postmortem/SKILL.md):
-# a 5-Whys root-cause analysis plus a hardening PR that prevents the bug class.
+# When a bug-fix PR is merged, open a tracking issue for the Puppets postmortem profile.
+# A trusted maintainer approves the issue before Puppets assigns the coding agent.
 #
 # Can also be dispatched manually for a specific PR (backfill / re-run).
 
@@ -32,13 +31,10 @@ jobs:
        !contains(github.event.pull_request.labels.*.name, 'postmortem'))
     runs-on: ubuntu-latest
     steps:
-      - name: Open postmortem issue and assign Copilot
+      - name: Open postmortem issue
         uses: actions/github-script@v7
         with:
-          # A user PAT with Issues/PR write assigns the Copilot coding agent
-          # (GITHUB_TOKEN cannot). Falls back to GITHUB_TOKEN, which still opens
-          # the tracking issue but leaves assignment to a maintainer.
-          github-token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -86,11 +82,6 @@ jobs:
                 color: '5319e7',
                 description: 'Automated 5-Whys postmortem for a merged bug fix',
               },
-              {
-                name: 'puppets:no-auto',
-                color: '000000',
-                description: 'Hard opt-out: Puppets automation must never touch this item.',
-              },
             ];
             for (const label of processLabels) {
               try {
@@ -115,27 +106,8 @@ jobs:
               ``,
               `---`,
               ``,
-              `@copilot Please follow the process defined in the repo file`,
-              `\`.github/skills/postmortem/SKILL.md\` for **PR #${pr.number}**:`,
-              ``,
-              `1. Reconstruct the bug from the PR diff and linked issue.`,
-              `2. Blame the introducing commit; classify regression vs. latent gap.`,
-              `3. Write a genuine **5 Whys** causal chain.`,
-              `4. Make **surgical hardening changes** (types/guards/invariants) plus a`,
-              `   regression test and generalized sibling-case tests that prevent this`,
-              `   *class* of bug — not just this instance.`,
-              `5. Validate with \`npm run build\` and \`npx vitest run\`.`,
-              `6. **Open a hardening PR** (\`postmortem/${pr.number}-<slug>\` branch)`,
-              `   that \`Closes #<this issue>\`. Put the full 5-Whys writeup in the PR`,
-              `   body between \`<!-- postmortem-writeup:start -->\` and`,
-              `   \`<!-- postmortem-writeup:end -->\` markers; the`,
-              `   \`postmortem-publish.yml\` workflow mirrors it here as a comment`,
-              `   automatically. Do **not** comment here yourself and do **not** merge.`,
-              ``,
-              `   The \`postmortem-guard.yml\` check enforces this: the PR must have`,
-              `   committed changes, a non-\`[WIP]\` ready-for-review title, a`,
-              `   non-empty 5-Whys writeup between the markers, and this \`Closes #\``,
-              `   reference — or the check fails.`,
+              `Apply \`puppets:approved\` after reviewing this tracking issue. Puppets will`,
+              `then assign the coding agent using \`.puppets/prompts/postmortem.md\`.`,
               ``,
               `_Automated by \`.github/workflows/postmortem.yml\`._`,
             ].join('\n');
@@ -144,46 +116,14 @@ jobs:
               owner, repo,
               title: `Postmortem: PR #${pr.number} — ${pr.title}`,
               body: issueBody,
-              labels: ['postmortem', 'puppets:no-auto'],
+              labels: ['postmortem'],
             });
             core.info(`Created postmortem issue #${issue.number}.`);
 
-            // ---- Assign the Copilot coding agent via GraphQL ----
-            // REST addAssignees with login "Copilot" silently no-ops; the coding
-            // agent must be assigned with replaceActorsForAssignable using the
-            // copilot-swe-agent bot node id from suggestedActors(CAN_BE_ASSIGNED).
-            let assigned = false;
-            try {
-              const suggested = await github.graphql(`
-                query($owner:String!,$repo:String!){
-                  repository(owner:$owner,name:$repo){
-                    suggestedActors(capabilities:[CAN_BE_ASSIGNED], first:100){
-                      nodes{ login __typename ... on Bot { id } ... on User { id } }
-                    }
-                  }
-                }`, { owner, repo });
-              const bot = suggested.repository.suggestedActors.nodes
-                .find(n => n.login === 'copilot-swe-agent' || n.login.toLowerCase() === 'copilot');
-              if (bot && bot.id) {
-                await github.graphql(`
-                  mutation($assignableId:ID!,$actorIds:[ID!]!){
-                    replaceActorsForAssignable(input:{assignableId:$assignableId, actorIds:$actorIds}){
-                      assignable { ... on Issue { number } }
-                    }
-                  }`, { assignableId: issue.node_id, actorIds: [bot.id] });
-                assigned = true;
-                core.info('Assigned Copilot coding agent to the postmortem issue.');
-              } else {
-                core.warning('Copilot coding agent not available as an assignee for this repo.');
-              }
-            } catch (e) {
-              core.warning(`Could not assign Copilot automatically: ${e.message}`);
-            }
-
             // ---- Link back from the PR (best-effort; don't fail the job) ----
-            const note = assigned
-              ? `🔬 Opened postmortem #${issue.number} and assigned the Copilot coding agent to run a 5-Whys analysis and propose hardening changes.`
-              : `🔬 Opened postmortem #${issue.number}. Assign it to the Copilot coding agent (or run the postmortem skill manually) to generate the 5-Whys analysis and hardening PR.`;
+            const note =
+              `🔬 Opened postmortem #${issue.number}. Review it and apply ` +
+              `\`puppets:approved\` to start the 5-Whys analysis and hardening work.`;
             try {
               await github.rest.issues.createComment({
                 owner, repo, issue_number: pr.number, body: note,

--- a/.github/workflows/puppets.yml
+++ b/.github/workflows/puppets.yml
@@ -18,15 +18,15 @@ concurrency:
 permissions:
   actions: write
   contents: read
+  id-token: write
   issues: write
   pull-requests: write
   copilot-requests: write
 
 jobs:
   reconcile:
-    uses: JeffSteinbok/puppets/.github/workflows/reconcile.yml@74799e6bf165504e864ef1d5346d06e86be8f705
+    uses: JeffSteinbok/puppets/.github/workflows/reconcile.yml@084dde59cecbb4dd59519e491377ac8cf5b34ad2
     with:
-      framework_ref: 74799e6bf165504e864ef1d5346d06e86be8f705
       dry_run: ${{ inputs.dry_run || false }}
       caller_workflow: puppets.yml
     secrets:

--- a/.puppets/config.json
+++ b/.puppets/config.json
@@ -9,9 +9,6 @@
   "conflictRetries": 2,
   "reviewRetries": 2,
   "copilotModel": "auto",
-  "enableCuration": true,
   "staleHours": 72,
-  "ignoreLabels": [
-    "postmortem"
-  ]
+  "ignoreLabels": []
 }

--- a/.puppets/implementation.md
+++ b/.puppets/implementation.md
@@ -3,6 +3,4 @@
 - Follow `.github/copilot-instructions.md` and repository-specific instruction files.
 - Keep changes scoped to the approved issue.
 - Validate with `npm run build` and `npx vitest run`.
-- Do not process issues labeled `postmortem`; they are owned by the repository's dedicated
-  postmortem workflows and `.github/skills/postmortem/SKILL.md`.
 - Never merge automatically.

--- a/.puppets/prompts/postmortem.md
+++ b/.puppets/prompts/postmortem.md
@@ -1,0 +1,11 @@
+Follow `.github/skills/postmortem/SKILL.md` exactly for the merged pull request identified
+in this issue.
+
+Use `npm run build` and `npx vitest run` for validation. The hardening pull request must:
+
+- use a `postmortem/<pr-number>-<slug>` branch;
+- close this tracking issue;
+- include the complete 5-Whys analysis between the repository's required
+  `postmortem-writeup` markers;
+- satisfy `.github/workflows/postmortem-guard.yml`; and
+- remain unmerged for maintainer review.

--- a/.puppets/workflow.yml
+++ b/.puppets/workflow.yml
@@ -1,0 +1,14 @@
+spec:
+  profiles:
+    - name: postmortem
+      default: false
+      priority: 100
+      selector:
+        allLabels:
+          - postmortem
+      routes:
+        approved: claim
+      implementation:
+        prompt: postmortem
+        guidance: null
+        heading: Puppets postmortem instructions

--- a/docs/POSTMORTEM.md
+++ b/docs/POSTMORTEM.md
@@ -17,7 +17,7 @@ users.
         │
         ▼
  postmortem.yml ───────────► opens a tracking issue (label: postmortem)
- (on: pull_request closed)    and assigns the Copilot coding agent
+ (on: pull_request closed)    for maintainer approval
         │
         ▼
  Copilot coding agent ──────► follows .github/skills/postmortem/SKILL.md:
@@ -36,7 +36,8 @@ users.
 
 | File | Trigger | Responsibility |
 | --- | --- | --- |
-| [`.github/workflows/postmortem.yml`](../.github/workflows/postmortem.yml) | a bug-fix PR is merged (or manual dispatch) | Opens the tracking issue and assigns the Copilot coding agent. |
+| [`.github/workflows/postmortem.yml`](../.github/workflows/postmortem.yml) | a bug-fix PR is merged (or manual dispatch) | Opens the tracking issue for approval. |
+| [`.puppets/workflow.yml`](../.puppets/workflow.yml) | Puppets reconciles an approved postmortem issue | Selects the postmortem prompt and routes directly to assignment. |
 | [`.github/skills/postmortem/SKILL.md`](../.github/skills/postmortem/SKILL.md) | read by the coding agent | The step-by-step 5-Whys + hardening process the agent follows. |
 | [`.github/workflows/postmortem-guard.yml`](../.github/workflows/postmortem-guard.yml) | the hardening PR opens/updates | Fails the check (and comments) if the PR isn't deliverable. |
 | [`.github/workflows/postmortem-publish.yml`](../.github/workflows/postmortem-publish.yml) | the hardening PR opens/updates | Mirrors the 5-Whys writeup from the PR body to the tracking issue. |
@@ -103,10 +104,10 @@ the API and never check out PR head code, so the elevated-trust context is safe.
 
 ## Tokens
 
-`postmortem.yml` and `postmortem-publish.yml` prefer a `PAT_TOKEN` secret
-(falling back to `GITHUB_TOKEN`). The PAT is needed to **assign the Copilot
-coding agent** (the default `GITHUB_TOKEN` cannot) and to comment on the separate
-tracking issue.
+`postmortem.yml` uses the repository `GITHUB_TOKEN` to open the tracking issue.
+Puppets uses its normal caller token policy when the approved issue is ready for
+coding-agent assignment. `postmortem-publish.yml` retains its existing token
+requirements for mirroring the writeup to the separate tracking issue.
 
 ## Running it manually
 


### PR DESCRIPTION
Moves postmortem assignment into the versioned Puppets workflow DSL. The repository trigger now only creates a labeled tracking issue; after trusted approval, the local postmortem profile routes directly to the repository prompt. Also adopts the single framework reference resolved from GitHub's signed OIDC claim.