### PR TITLE
Use standard Puppets token secret

### DIFF
--- a/.github/workflows/puppets.yml
+++ b/.github/workflows/puppets.yml
@@ -30,4 +30,4 @@ jobs:
       dry_run: ${{ inputs.dry_run || false }}
       caller_workflow: puppets.yml
     secrets:
-      token: ${{ secrets.PAT_TOKEN }}
+      token: ${{ secrets.PUPPETS_TOKEN }}


### PR DESCRIPTION
Updates the caller to use the consistent repository secret name PUPPETS_TOKEN.