### PR TITLE
Support work, school, and tenant (Entra ID) accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ![Social Preview](socialPreview.png)
 
-Sync your Obsidian vault with **OneDrive Personal** accounts. Zero-config, mobile-friendly, battery-efficient.
+Sync your Obsidian vault with **OneDrive**. Zero-config for personal Microsoft accounts; work and school (Entra ID) accounts are also supported with a one-time app registration. Mobile-friendly, battery-efficient.
 
 📖 [How It Works](docs/HOW_IT_WORKS.md) · [Troubleshooting](docs/TROUBLESHOOTING.md) · [Advanced Usage](docs/ADVANCED.md) · [Development](docs/DEVELOPMENT.md) · [Postmortem Process](docs/POSTMORTEM.md)
 
@@ -18,7 +18,8 @@ Sync your Obsidian vault with **OneDrive Personal** accounts. Zero-config, mobil
 
 ## ✨ Features
 
-- **Zero-Configuration** — No Azure AD app registration. Just click connect and authenticate.
+- **Zero-Configuration for Personal Accounts** — No Azure AD app registration needed. Just click connect and authenticate.
+- **Work and School Accounts** — Entra ID (Microsoft 365 Business/Enterprise) accounts are supported with your own app registration. See [Advanced Usage](docs/ADVANCED.md#account-types).
 - **Mobile-First** — Device Code Flow works on iOS and Android with no redirects.
 - **Event-Driven Sync** — Syncs on file changes, not polling. Great for battery life.
 - **Bidirectional** — Automatic two-way sync with configurable conflict resolution.
@@ -62,6 +63,9 @@ Sync your Obsidian vault with **OneDrive Personal** accounts. Zero-config, mobil
 2. Enter the displayed code at [microsoft.com/devicelogin](https://microsoft.com/devicelogin)
 3. Sign in and grant permissions
 4. Done — your vault syncs automatically!
+
+> [!NOTE]
+> Signing in with a work or school (Entra ID) account? Set **Account type** in settings first — see [Account Types](docs/ADVANCED.md#account-types) for the one-time app registration these accounts require.
 
 ### Configuration
 

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -25,7 +25,21 @@ private/
 attachments/videos/
 ```
 
+## Account Types
+
+Settings → OneDrive Sync → Authentication → **Account type** controls which Microsoft identity authority the plugin signs in against:
+
+| Account type | Use for | Custom client ID |
+| ------------ | ------- | ----------------- |
+| **Personal** (default) | Consumer Microsoft accounts (outlook.com, hotmail.com, live.com) | Optional |
+| **Work or school (any organization)** | An Entra ID (Azure AD) work or school account, without pinning a specific tenant | **Required** |
+| **Work or school (specific organization)** | One named Entra ID tenant, identified by its tenant ID | **Required** |
+
+Personal accounts keep working exactly as before — this setting defaults to Personal and existing installs are unaffected. Work and school accounts (OneDrive for Business, backed by SharePoint Online) need their own app registration, covered below.
+
 ## Custom Client ID
+
+### Personal Microsoft accounts
 
 By default the plugin uses a shared Azure AD app registration. For privacy or rate-limit reasons you can bring your own:
 
@@ -39,6 +53,36 @@ By default the plugin uses a shared Azure AD app registration. For privacy or ra
 
 Then paste the client ID into Settings → OneDrive Sync → Advanced → Custom client ID.
 
+### Work or school (Entra ID) accounts
+
+The client ID bundled with the plugin is registered for **personal Microsoft accounts only** — Microsoft Graph rejects it immediately for a work or school sign-in. Work and school accounts must register their own application:
+
+1. Go to [Azure Portal](https://portal.azure.com) → Microsoft Entra ID → App registrations
+2. Click **New registration**
+3. Name: `Obsidian OneDrive Sync` (or anything you like)
+4. Supported account types: **Accounts in this organizational directory only** (for the "specific organization" account type) or **Accounts in any organizational directory** (for "any organization")
+5. Redirect URI: Leave blank (device code flow needs none)
+6. After registration, copy the **Application (client) ID**, and the **Directory (tenant) ID** if you plan to use the "specific organization" account type
+7. Under **Authentication** → enable **Allow public client flows**
+8. Under **API permissions** → add delegated Microsoft Graph permissions: `User.Read`, `offline_access`, and `Files.ReadWrite.All`. Work and school accounts always run in Full Access mode, which includes browsing and syncing folders shared with the user — that reads other drives, which plain `Files.ReadWrite` does not cover
+9. Click **Grant admin consent** — many tenants require this before any user can sign in, regardless of the permissions requested
+
+Then in Settings → OneDrive Sync:
+1. Set **Account type** to the matching work/school option
+2. For "specific organization", paste the **Tenant ID**
+3. Paste the **Application (client) ID** into **Custom client ID** — this field becomes required (not optional) once account type is not Personal
+4. Connect as usual via the device code flow
+
+## Work and School Account Limitations
+
+**App Folder mode is unavailable.** Microsoft Graph does not offer the `Files.ReadWrite.AppFolder` scope to work or school accounts, so the plugin restricts these accounts to Full Access mode and hides the App Folder option in settings. Recommended layout: pick a dedicated folder (e.g. `/Documents/ObsidianVaults/<VaultName>`) and set it as the sync folder under Full Access, rather than pointing the vault at the drive root.
+
+**Vault placement.** If this is a work machine, the OneDrive desktop client is likely already running and signed in, mirroring your OneDrive for Business drive to disk. The plugin syncs independently through Obsidian's vault API and Microsoft Graph — it never reads that local mirror — so the two do not interfere, **unless the vault itself is placed inside the OneDrive client's synced folder**. In that case two independent syncers would act on the same files. Keep the vault outside the OneDrive client's local sync folder so the plugin is the only writer.
+
+**Conditional Access can block sign-in entirely.** Some tenants have a Conditional Access policy that forbids the OAuth device code grant outright (the only sign-in method this plugin supports, by design — see the mobile-compatibility note in `src/auth/deviceCodeFlow.ts`). If your organization has such a policy, authentication will fail with a message naming the organization's policy as the cause, and there is no workaround within the plugin; ask your administrator whether device code sign-in can be permitted for this app, or use OneDrive's native sync instead. **This restriction is often stricter for mobile than desktop** — a tenant's Conditional Access policy may require a compliant device or an approved client app, conditions a desktop browser can satisfy that the Obsidian mobile app cannot. It is possible for a tenant to allow this plugin on desktop while blocking it on iOS and Android, the platform this feature exists to serve.
+
+**Continuous Access Evaluation (CAE).** Business tenants can revoke a token mid-session in response to a risk signal (e.g. a password reset, or the user being disabled), via a mechanism this plugin does not implement support for. If you see an unexpected "please reconnect" prompt with no obvious cause, CAE is a likely explanation — simply reconnect.
+
 ## Advanced Settings
 
 These settings are available under Settings → OneDrive Sync → Advanced:
@@ -49,7 +93,9 @@ These settings are available under Settings → OneDrive Sync → Advanced:
 | **Large Delete Warning Threshold** | Pause and ask before a sync that would delete this many files. Helps catch unintended remote deletions. Set to 0 to disable. |
 | **Reset Sync Token** | Force a full re-read from OneDrive on the next sync. Use if files appear missing or out of date. Upload-biased: local-only files will be re-uploaded. |
 | **Reconcile from Cloud** | Treat cloud as authoritative. Deletes local files that no longer exist in OneDrive and downloads anything missing. Destructive — confirmation required for large deletes. |
-| **Custom Client ID** | Use your own Azure AD app registration (see above). |
+| **Account Type** | Personal, work/school (any organization), or work/school (specific organization). See [Account Types](#account-types) above. |
+| **Tenant ID** | Only shown for the "specific organization" account type. |
+| **Custom Client ID** | Use your own Azure AD app registration (see above). Required — not optional — for work and school accounts. |
 
 ## Experimental Settings
 

--- a/src/auth/deviceCodeFlow.ts
+++ b/src/auth/deviceCodeFlow.ts
@@ -30,22 +30,12 @@
  */
 
 import { requestUrl } from 'obsidian';
-import {
-	DeviceCodeResponse,
-	TokenResponse,
-	AuthenticationError,
-	OneDriveError,
-	OneDriveAccessMode,
-} from '../types';
-import {
-	OAUTH_ENDPOINTS,
-	OAUTH_SCOPES_APP_FOLDER,
-	OAUTH_SCOPES_FULL_ACCESS,
-	DEFAULT_ONEDRIVE_CLIENT_ID,
-} from '../constants';
+import { DeviceCodeResponse, TokenResponse, AuthenticationError, OneDriveError } from '../types';
+import { OAuthEndpointSet, OAUTH_ENDPOINTS, OAUTH_SCOPES_APP_FOLDER, DEFAULT_ONEDRIVE_CLIENT_ID } from '../constants';
 import { logger } from '../utils/logger';
 import { parseHttpError } from '../utils/errors';
 import { sleep } from '../utils/retry';
+import { mapEntraAuthError } from './entraErrors';
 
 interface OAuthErrorResponse {
 	error?: string;
@@ -56,8 +46,9 @@ export class DeviceCodeFlowClient {
 	private cancelled = false;
 
 	constructor(
-		private clientId: string = DEFAULT_ONEDRIVE_CLIENT_ID,
-		private accessMode: OneDriveAccessMode = OneDriveAccessMode.APP_FOLDER
+		private endpoints: OAuthEndpointSet = OAUTH_ENDPOINTS,
+		private scopes: string[] = OAUTH_SCOPES_APP_FOLDER,
+		private clientId: string = DEFAULT_ONEDRIVE_CLIENT_ID
 	) {}
 
 	/**
@@ -72,27 +63,32 @@ export class DeviceCodeFlowClient {
 	 * Returns the device code and user code for the user to enter
 	 */
 	async requestDeviceCode(): Promise<DeviceCodeResponse> {
-		const scopes =
-			this.accessMode === OneDriveAccessMode.FULL_ACCESS
-				? OAUTH_SCOPES_FULL_ACCESS
-				: OAUTH_SCOPES_APP_FOLDER;
-
-		logger.debug('Requesting device code with scopes:', scopes);
+		logger.debug('Requesting device code with scopes:', this.scopes);
 
 		try {
 			const response = await requestUrl({
-				url: OAUTH_ENDPOINTS.DEVICE_CODE,
+				url: this.endpoints.DEVICE_CODE,
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},
 				body: new URLSearchParams({
 					client_id: this.clientId,
-					scope: scopes.join(' '),
+					scope: this.scopes.join(' '),
 				}).toString(),
+				// Without this, requestUrl throws on 4xx before we can read the
+				// body — and the body is where Entra puts the AADSTS code that
+				// explains work/school failures (unapproved app, tenant policy,
+				// wrong account type).
+				throw: false,
 			});
 
 			if (response.status !== 200) {
+				const errorData = this.parseErrorResponse(response);
+				const mappedMessage = mapEntraAuthError(errorData.error, errorData.error_description);
+				if (mappedMessage) {
+					throw new AuthenticationError(mappedMessage, errorData.error);
+				}
 				throw parseHttpError(response.status, response.text);
 			}
 
@@ -103,9 +99,26 @@ export class DeviceCodeFlowClient {
 			return data;
 		} catch (error) {
 			logger.error('Failed to request device code:', error);
+			if (error instanceof AuthenticationError) {
+				// Already actionable (a mapped Entra rejection) — don't bury it
+				// behind a generic prefix.
+				throw error;
+			}
 			throw new AuthenticationError(
 				`Failed to request device code: ${error instanceof Error ? error.message : 'Unknown error'}`
 			);
+		}
+	}
+
+	/**
+	 * Read an OAuth error body defensively: a non-JSON or empty response makes
+	 * `requestUrl`'s `json` getter throw or yield null.
+	 */
+	private parseErrorResponse(response: { json: unknown }): OAuthErrorResponse {
+		try {
+			return (response.json as OAuthErrorResponse) ?? {};
+		} catch {
+			return {};
 		}
 	}
 
@@ -138,7 +151,7 @@ export class DeviceCodeFlowClient {
 
 			try {
 				const response = await requestUrl({
-					url: OAUTH_ENDPOINTS.TOKEN,
+					url: this.endpoints.TOKEN,
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/x-www-form-urlencoded',
@@ -161,8 +174,15 @@ export class DeviceCodeFlowClient {
 				consecutiveNetworkErrors = 0;
 
 				// Handle error responses (including 400s from Obsidian's requestUrl)
-				const errorData = response.json as unknown as OAuthErrorResponse;
+				const errorData = this.parseErrorResponse(response);
 				const errorCode = errorData.error;
+
+				const mappedMessage = mapEntraAuthError(errorCode, errorData.error_description);
+				if (mappedMessage) {
+					// Stop polling — a rejection Entra names (tenant policy, unapproved
+					// app, wrong account type) will not resolve on retry.
+					throw new AuthenticationError(mappedMessage, errorCode);
+				}
 
 				if (errorCode === 'authorization_pending') {
 					// User hasn't completed auth yet, continue polling
@@ -212,7 +232,7 @@ export class DeviceCodeFlowClient {
 
 		try {
 			const response = await requestUrl({
-				url: OAUTH_ENDPOINTS.TOKEN,
+				url: this.endpoints.TOKEN,
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',

--- a/src/auth/entraErrors.ts
+++ b/src/auth/entraErrors.ts
@@ -1,0 +1,44 @@
+/**
+ * Maps Entra ID (Azure AD) error codes surfaced during the device code grant to
+ * messages a user can act on, instead of raw AADSTS codes.
+ */
+
+import { t } from '../i18n';
+
+const CONDITIONAL_ACCESS_CODES = ['AADSTS53003'];
+const APP_NOT_AUTHORIZED_CODES = ['AADSTS700016', 'AADSTS65001', 'AADSTS90094'];
+const ACCOUNT_TYPE_MISMATCH_CODES = ['AADSTS50020', 'AADSTS90072'];
+
+// Match on a whole code only. A bare substring test would let a longer code
+// that shares a prefix (AADSTS530032 vs AADSTS53003) be reported as an
+// unrelated cause — and because a match aborts polling, that misdiagnosis is
+// fatal rather than cosmetic.
+function includesAnyCode(text: string, codes: string[]): boolean {
+	return codes.some((code) => new RegExp(`\\b${code}\\b`).test(text));
+}
+
+/**
+ * Returns a user-facing message for a known Entra rejection, or undefined if
+ * the error doesn't match a recognized cause (caller should fall back to a
+ * generic message).
+ */
+export function mapEntraAuthError(
+	errorCode: string | undefined,
+	errorDescription: string | undefined
+): string | undefined {
+	// Entra usually puts the AADSTS code in the description, but the /devicecode
+	// endpoint can also surface it as the error code itself — search both.
+	const text = `${errorCode || ''} ${errorDescription || ''}`;
+
+	if (includesAnyCode(text, CONDITIONAL_ACCESS_CODES)) {
+		return t('notices.auth.entra.conditionalAccessBlocked');
+	}
+	if (includesAnyCode(text, APP_NOT_AUTHORIZED_CODES)) {
+		return t('notices.auth.entra.appNotAuthorized');
+	}
+	if (includesAnyCode(text, ACCOUNT_TYPE_MISMATCH_CODES)) {
+		return t('notices.auth.entra.accountTypeMismatch');
+	}
+
+	return undefined;
+}

--- a/src/auth/index.ts
+++ b/src/auth/index.ts
@@ -22,7 +22,7 @@
  * import { DeviceCodeFlowClient, OneDriveAuthProvider, TokenStorage } from './auth';
  *
  * const tokenStorage = new TokenStorage();
- * const deviceCodeClient = new DeviceCodeFlowClient(clientId, accessMode);
+ * const deviceCodeClient = new DeviceCodeFlowClient(endpoints, scopes, clientId);
  * const authProvider = new OneDriveAuthProvider(tokenStorage, deviceCodeClient);
  *
  * // Use authProvider with Microsoft Graph Client

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,29 +2,93 @@
  * Constants for OneDrive OAuth and API integration
  */
 
-// OAuth 2.0 Device Code Flow endpoints
-export const OAUTH_ENDPOINTS = {
-	DEVICE_CODE: 'https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode',
-	TOKEN: 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token',
-	AUTHORIZE: 'https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize',
-};
+import { AccountType, OneDriveAccessMode } from './types';
+
+// Global Microsoft identity host. Passed as a parameter of resolveOAuthEndpoints()
+// so a national cloud (US Government, 21Vianet) can supply a different host later.
+export const IDENTITY_HOST = 'https://login.microsoftonline.com';
+
+export interface OAuthEndpointSet {
+	DEVICE_CODE: string;
+	TOKEN: string;
+	AUTHORIZE: string;
+}
+
+// A tenant ID is either a directory GUID or a verified domain
+// (contoso.onmicrosoft.com). Anything else — surrounding whitespace from a
+// portal copy/paste, a pasted full authority URL, a stray path segment —
+// would silently rewrite the authority URL, so reject it up front instead of
+// sending a malformed request and reporting an opaque 400.
+const TENANT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9.-]*$/;
+
+/** Resolve the OAuth endpoints for an account type. Throws if a tenant ID is required but unusable. */
+export function resolveOAuthEndpoints(
+	accountType: AccountType,
+	tenantId: string | undefined,
+	identityHost: string = IDENTITY_HOST
+): OAuthEndpointSet {
+	let segment: string;
+	if (accountType === 'personal') {
+		segment = 'consumers';
+	} else if (accountType === 'work-school') {
+		segment = 'organizations';
+	} else {
+		const trimmedTenantId = tenantId?.trim();
+		if (!trimmedTenantId) {
+			throw new Error('A tenant ID is required for the tenant account type');
+		}
+		if (!TENANT_ID_PATTERN.test(trimmedTenantId)) {
+			throw new Error(
+				`Invalid tenant ID "${trimmedTenantId}". Use the directory (tenant) ID or a verified domain name.`
+			);
+		}
+		segment = trimmedTenantId;
+	}
+
+	return {
+		DEVICE_CODE: `${identityHost}/${segment}/oauth2/v2.0/devicecode`,
+		TOKEN: `${identityHost}/${segment}/oauth2/v2.0/token`,
+		AUTHORIZE: `${identityHost}/${segment}/oauth2/v2.0/authorize`,
+	};
+}
+
+// Default endpoint set for callers without a configured identity (e.g. constructor defaults).
+export const OAUTH_ENDPOINTS = resolveOAuthEndpoints('personal', undefined);
 
 // Microsoft Graph API
 export const GRAPH_API_ENDPOINT = 'https://graph.microsoft.com/v1.0';
 
-// OAuth scopes for App Folder mode (default - secure, isolated)
+// OAuth scopes for App Folder mode (default - secure, isolated). Personal accounts only.
 export const OAUTH_SCOPES_APP_FOLDER = [
 	'User.Read', // Read user profile
 	'Files.ReadWrite.AppFolder', // Read/write app-specific folder only
 	'offline_access', // Enable refresh tokens
 ];
 
-// OAuth scopes for Full Access mode (advanced - for sharing)
+// OAuth scopes for Full Access mode (advanced - for sharing). Personal accounts only.
 export const OAUTH_SCOPES_FULL_ACCESS = [
 	'User.Read', // Read user profile
 	'Files.ReadWrite.All', // Read/write access to all OneDrive files
 	'offline_access', // Enable refresh tokens
 ];
+
+// OAuth scopes for work/school accounts. Files.ReadWrite.AppFolder is not offered
+// to work or school accounts, so these accounts always use Full Access mode —
+// which includes the shared-folder browser. Browsing and syncing a folder on
+// another drive needs Files.ReadWrite.All; plain Files.ReadWrite only covers the
+// signed-in user's own drive and would 403 as soon as a shared folder is picked.
+export const OAUTH_SCOPES_WORK_SCHOOL = [
+	'User.Read', // Read user profile
+	'Files.ReadWrite.All', // Read/write access to the user's files and shared folders
+	'offline_access', // Enable refresh tokens
+];
+
+export function resolveOAuthScopes(accountType: AccountType, accessMode: OneDriveAccessMode): string[] {
+	if (accountType !== 'personal') {
+		return OAUTH_SCOPES_WORK_SCHOOL;
+	}
+	return accessMode === OneDriveAccessMode.FULL_ACCESS ? OAUTH_SCOPES_FULL_ACCESS : OAUTH_SCOPES_APP_FOLDER;
+}
 
 // Default OneDrive client ID (registered Azure AD app)
 export const DEFAULT_ONEDRIVE_CLIENT_ID = '49ec1ec3-7237-4b7b-89e0-aeb6565fc70b';

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -56,6 +56,20 @@ export const de = {
 			connectSuccess: 'Erfolgreich mit OneDrive verbunden',
 			connectFailed: 'Verbindung zu OneDrive fehlgeschlagen: {{message}}',
 			disconnectSuccess: 'Von OneDrive getrennt',
+			customClientIdRequired:
+				'Geschäfts- und Schulkonten benötigen eine benutzerdefinierte Client-ID. In der Einrichtungsdokumentation erfahren Sie, wie Sie Ihre eigene Anwendung registrieren.',
+			tenantIdRequired: 'Für den Kontotyp „Mandant“ ist eine Mandanten-ID erforderlich.',
+			reconnectRequiredIdentityChanged: 'Kontoeinstellungen geändert. Bitte erneut mit OneDrive verbinden.',
+			accessModeSwitchedToFullAccess:
+				'Der App-Ordner-Modus ist für geschäftliche und Schulkonten nicht verfügbar. Der Zugriffsmodus wurde auf Vollzugriff umgestellt.',
+			entra: {
+				conditionalAccessBlocked:
+					'Die Richtlinie Ihrer Organisation blockiert diese Anmeldemethode. Wenden Sie sich an Ihren Administrator oder verwenden Sie ein anderes Gerät.',
+				appNotAuthorized:
+					'Diese Anwendung ist in Ihrer Organisation noch nicht genehmigt. Bitten Sie einen Administrator, die App-Registrierung zu genehmigen.',
+				accountTypeMismatch:
+					'Das angemeldete Konto stimmt nicht mit dem konfigurierten Kontotyp überein. Überprüfen Sie den Kontotyp in den Einstellungen.',
+			},
 		},
 		sync: {
 			stateCleared: 'Synchronisierungsstatus gelöscht. Vollständige Synchronisierung wird ausgeführt...',
@@ -178,6 +192,18 @@ export const de = {
 	settings: {
 		auth: {
 			heading: 'Authentifizierung',
+			accountType: {
+				name: 'Kontotyp',
+				desc: 'Wählen Sie, mit welcher Art von Microsoft-Konto Sie sich verbinden.',
+				personal: 'Privat (Microsoft-Konto)',
+				workSchool: 'Geschäftlich oder Schule (beliebige Organisation)',
+				tenant: 'Geschäftlich oder Schule (bestimmte Organisation)',
+				tenantIdName: 'Mandanten-ID',
+				tenantIdDesc: 'Die Entra ID-Mandanten-ID (Verzeichnis-ID), gegen die angemeldet wird.',
+				tenantIdPlaceholder: 'z. B. 11111111-1111-1111-1111-111111111111',
+				appFolderUnavailable: 'Der App-Ordner-Modus ist für geschäftliche und Schulkonten nicht verfügbar.',
+				reconnectRequired: ' Diese Änderung erfordert eine erneute Verbindung.',
+			},
 			accessMode: {
 				name: 'OneDrive-Zugriffsmodus',
 				appFolder: 'App-Ordner (Empfohlen)',
@@ -312,6 +338,7 @@ export const de = {
 				name: 'Benutzerdefinierte Client-ID',
 				desc: 'Ihre Azure AD-Anwendungs-(Client-)ID',
 				helpPrefix: 'Siehe ',
+				requiredNote: ' Für Geschäfts- und Schulkonten erforderlich.',
 				helpLink: 'Anleitung zur Einrichtung einer benutzerdefinierten Client-ID',
 				helpSuffix: ' im README.',
 			},

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -56,6 +56,20 @@ export const en = {
 			connectSuccess: 'Successfully connected to OneDrive',
 			connectFailed: 'Failed to connect to OneDrive: {{message}}',
 			disconnectSuccess: 'Disconnected from OneDrive',
+			customClientIdRequired:
+				'Work and school accounts require a custom client ID. See the setup documentation to register your own application.',
+			tenantIdRequired: 'A tenant ID is required for the tenant account type.',
+			reconnectRequiredIdentityChanged: 'Account settings changed. Please reconnect to OneDrive.',
+			accessModeSwitchedToFullAccess:
+				'App Folder mode is unavailable for work and school accounts. Access mode switched to Full Access.',
+			entra: {
+				conditionalAccessBlocked:
+					"Your organization's policy blocks this sign-in method. Contact your administrator, or try a different device.",
+				appNotAuthorized:
+					'This application is not yet approved in your organization. Ask an administrator to approve the app registration.',
+				accountTypeMismatch:
+					'The signed-in account does not match the configured account type. Check the account type in settings.',
+			},
 		},
 		sync: {
 			stateCleared: 'Sync state cleared. Running full sync...',
@@ -178,6 +192,18 @@ export const en = {
 	settings: {
 		auth: {
 			heading: 'Authentication',
+			accountType: {
+				name: 'Account type',
+				desc: 'Choose which kind of Microsoft account you are connecting with.',
+				personal: 'Personal (Microsoft account)',
+				workSchool: 'Work or school (any organization)',
+				tenant: 'Work or school (specific organization)',
+				tenantIdName: 'Tenant ID',
+				tenantIdDesc: "The Entra ID tenant (directory) ID to sign in against.",
+				tenantIdPlaceholder: 'e.g. 11111111-1111-1111-1111-111111111111',
+				appFolderUnavailable: 'App Folder mode is unavailable for work and school accounts.',
+				reconnectRequired: ' Changing this requires reconnecting.',
+			},
 			accessMode: {
 				name: 'OneDrive access mode',
 				appFolder: 'App Folder (Recommended)',
@@ -315,6 +341,7 @@ export const en = {
 					'Use your own Azure AD app registration. See the README for setup instructions.',
 				name: 'Custom client ID',
 				desc: 'Your Azure AD Application (client) ID',
+				requiredNote: ' Required for work and school accounts.',
 				helpPrefix: 'See ',
 				helpLink: 'Custom Client ID setup guide',
 				helpSuffix: ' in the README.',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -56,6 +56,20 @@ export const es = {
 			connectSuccess: 'Conectado exitosamente a OneDrive',
 			connectFailed: 'Error al conectar a OneDrive: {{message}}',
 			disconnectSuccess: 'Desconectado de OneDrive',
+			customClientIdRequired:
+				'Las cuentas de trabajo o escuela requieren un ID de cliente personalizado. Consulta la documentación de configuración para registrar tu propia aplicación.',
+			tenantIdRequired: 'Se requiere un ID de inquilino para el tipo de cuenta de inquilino.',
+			reconnectRequiredIdentityChanged: 'La configuración de la cuenta cambió. Por favor, vuelve a conectarte a OneDrive.',
+			accessModeSwitchedToFullAccess:
+				'El modo de carpeta de la app no está disponible para cuentas de trabajo o escuela. El modo de acceso cambió a Acceso completo.',
+			entra: {
+				conditionalAccessBlocked:
+					'La política de tu organización bloquea este método de inicio de sesión. Contacta a tu administrador o prueba con otro dispositivo.',
+				appNotAuthorized:
+					'Esta aplicación aún no está aprobada en tu organización. Pide a un administrador que apruebe el registro de la aplicación.',
+				accountTypeMismatch:
+					'La cuenta con la que iniciaste sesión no coincide con el tipo de cuenta configurado. Verifica el tipo de cuenta en la configuración.',
+			},
 		},
 		sync: {
 			stateCleared: 'Estado de sincronización limpiado. Ejecutando sincronización completa...',
@@ -178,6 +192,18 @@ export const es = {
 	settings: {
 		auth: {
 			heading: 'Autenticación',
+			accountType: {
+				name: 'Tipo de cuenta',
+				desc: 'Elige con qué tipo de cuenta de Microsoft te estás conectando.',
+				personal: 'Personal (cuenta de Microsoft)',
+				workSchool: 'Trabajo o escuela (cualquier organización)',
+				tenant: 'Trabajo o escuela (organización específica)',
+				tenantIdName: 'ID de inquilino',
+				tenantIdDesc: 'El ID de inquilino (directorio) de Entra ID contra el que iniciar sesión.',
+				tenantIdPlaceholder: 'p. ej. 11111111-1111-1111-1111-111111111111',
+				appFolderUnavailable: 'El modo de carpeta de la app no está disponible para cuentas de trabajo o escuela.',
+				reconnectRequired: ' Cambiar esto requiere reconectar.',
+			},
 			accessMode: {
 				name: 'Modo de acceso a OneDrive',
 				appFolder: 'Carpeta de aplicación (Recomendado)',
@@ -312,6 +338,7 @@ export const es = {
 				name: 'ID de cliente personalizado',
 				desc: 'Tu ID de Aplicación (cliente) de Azure AD',
 				helpPrefix: 'Consulta ',
+				requiredNote: ' Requerido para cuentas de trabajo o escuela.',
 				helpLink: 'Guía de configuración de ID de cliente personalizado',
 				helpSuffix: ' en el README.',
 			},

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -56,6 +56,20 @@ export const fr = {
 			connectSuccess: 'Connecté avec succès à OneDrive',
 			connectFailed: 'Échec de la connexion à OneDrive: {{message}}',
 			disconnectSuccess: 'Déconnecté de OneDrive',
+			customClientIdRequired:
+				"Les comptes professionnels ou scolaires nécessitent un ID client personnalisé. Consultez la documentation de configuration pour enregistrer votre propre application.",
+			tenantIdRequired: 'Un ID de locataire est requis pour le type de compte locataire.',
+			reconnectRequiredIdentityChanged: 'Paramètres du compte modifiés. Veuillez vous reconnecter à OneDrive.',
+			accessModeSwitchedToFullAccess:
+				"Le mode Dossier d'application n'est pas disponible pour les comptes professionnels ou scolaires. Le mode d'accès est passé à Accès complet.",
+			entra: {
+				conditionalAccessBlocked:
+					'La politique de votre organisation bloque cette méthode de connexion. Contactez votre administrateur ou essayez un autre appareil.',
+				appNotAuthorized:
+					"Cette application n'est pas encore approuvée dans votre organisation. Demandez à un administrateur d'approuver l'enregistrement de l'application.",
+				accountTypeMismatch:
+					'Le compte connecté ne correspond pas au type de compte configuré. Vérifiez le type de compte dans les paramètres.',
+			},
 		},
 		sync: {
 			stateCleared: 'État de synchronisation effacé. Exécution d\'une synchronisation complète...',
@@ -178,6 +192,18 @@ export const fr = {
 	settings: {
 		auth: {
 			heading: 'Authentification',
+			accountType: {
+				name: 'Type de compte',
+				desc: 'Choisissez le type de compte Microsoft avec lequel vous vous connectez.',
+				personal: 'Personnel (compte Microsoft)',
+				workSchool: 'Professionnel ou scolaire (toute organisation)',
+				tenant: 'Professionnel ou scolaire (organisation spécifique)',
+				tenantIdName: 'ID de locataire',
+				tenantIdDesc: "L'ID de locataire (répertoire) Entra ID auquel se connecter.",
+				tenantIdPlaceholder: 'ex. 11111111-1111-1111-1111-111111111111',
+				appFolderUnavailable: "Le mode Dossier d'application n'est pas disponible pour les comptes professionnels ou scolaires.",
+				reconnectRequired: ' Cette modification nécessite une reconnexion.',
+			},
 			accessMode: {
 				name: 'Mode d\'accès OneDrive',
 				appFolder: 'Dossier d\'application (Recommandé)',
@@ -312,6 +338,7 @@ export const fr = {
 				name: 'ID client personnalisé',
 				desc: 'Votre ID d\'Application (client) Azure AD',
 				helpPrefix: 'Voir ',
+				requiredNote: ' Requis pour les comptes professionnels ou scolaires.',
 				helpLink: 'Guide de configuration d\'ID client personnalisé',
 				helpSuffix: ' dans le README.',
 			},

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -56,6 +56,20 @@ export const it = {
 			connectSuccess: 'Connesso con successo a OneDrive',
 			connectFailed: 'Connessione a OneDrive fallita: {{message}}',
 			disconnectSuccess: 'Disconnesso da OneDrive',
+			customClientIdRequired:
+				'Gli account di lavoro o scuola richiedono un ID client personalizzato. Consulta la documentazione di configurazione per registrare la tua applicazione.',
+			tenantIdRequired: 'È richiesto un ID tenant per il tipo di account tenant.',
+			reconnectRequiredIdentityChanged: 'Impostazioni account modificate. Riconnettiti a OneDrive.',
+			accessModeSwitchedToFullAccess:
+				'La modalità Cartella app non è disponibile per account di lavoro o scuola. Modalità di accesso cambiata in Accesso completo.',
+			entra: {
+				conditionalAccessBlocked:
+					'La policy della tua organizzazione blocca questo metodo di accesso. Contatta il tuo amministratore o prova un altro dispositivo.',
+				appNotAuthorized:
+					"Questa applicazione non è ancora approvata nella tua organizzazione. Chiedi a un amministratore di approvare la registrazione dell'app.",
+				accountTypeMismatch:
+					"L'account con cui hai effettuato l'accesso non corrisponde al tipo di account configurato. Controlla il tipo di account nelle impostazioni.",
+			},
 		},
 		sync: {
 			stateCleared: 'Stato sincronizzazione cancellato. Esecuzione sincronizzazione completa...',
@@ -178,6 +192,18 @@ export const it = {
 	settings: {
 		auth: {
 			heading: 'Autenticazione',
+			accountType: {
+				name: 'Tipo di account',
+				desc: 'Scegli con quale tipo di account Microsoft ti stai connettendo.',
+				personal: 'Personale (account Microsoft)',
+				workSchool: 'Lavoro o scuola (qualsiasi organizzazione)',
+				tenant: 'Lavoro o scuola (organizzazione specifica)',
+				tenantIdName: 'ID tenant',
+				tenantIdDesc: "L'ID tenant (directory) Entra ID a cui accedere.",
+				tenantIdPlaceholder: 'es. 11111111-1111-1111-1111-111111111111',
+				appFolderUnavailable: 'La modalità Cartella app non è disponibile per account di lavoro o scuola.',
+				reconnectRequired: ' Questa modifica richiede una riconnessione.',
+			},
 			accessMode: {
 				name: 'Modalità accesso OneDrive',
 				appFolder: 'Cartella app (Consigliato)',
@@ -312,6 +338,7 @@ export const it = {
 				name: 'ID client personalizzato',
 				desc: 'Il tuo ID Applicazione (client) Azure AD',
 				helpPrefix: 'Vedi ',
+				requiredNote: ' Richiesto per account di lavoro o scuola.',
 				helpLink: 'Guida configurazione ID client personalizzato',
 				helpSuffix: ' nel README.',
 			},

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -56,6 +56,19 @@ export const ja = {
 			connectSuccess: 'OneDriveに正常に接続しました',
 			connectFailed: 'OneDriveへの接続に失敗しました: {{message}}',
 			disconnectSuccess: 'OneDriveから切断しました',
+			customClientIdRequired:
+				'職場または学校アカウントにはカスタムクライアントIDが必要です。独自のアプリケーションを登録する方法はセットアップドキュメントを参照してください。',
+			tenantIdRequired: 'テナントアカウントタイプにはテナントIDが必要です。',
+			reconnectRequiredIdentityChanged: 'アカウント設定が変更されました。OneDriveに再接続してください。',
+			accessModeSwitchedToFullAccess:
+				'アプリフォルダーモードは職場または学校アカウントでは利用できません。アクセスモードはフルアクセスに切り替わりました。',
+			entra: {
+				conditionalAccessBlocked:
+					'組織のポリシーによりこのサインイン方法はブロックされています。管理者に連絡するか、別のデバイスをお試しください。',
+				appNotAuthorized: 'このアプリケーションは組織でまだ承認されていません。管理者にアプリ登録の承認を依頼してください。',
+				accountTypeMismatch:
+					'サインインしたアカウントが設定されたアカウントタイプと一致しません。設定でアカウントタイプを確認してください。',
+			},
 		},
 		sync: {
 			stateCleared: '同期状態がクリアされました。完全同期を実行中...',
@@ -178,6 +191,18 @@ export const ja = {
 	settings: {
 		auth: {
 			heading: '認証',
+			accountType: {
+				name: 'アカウントの種類',
+				desc: '接続するMicrosoftアカウントの種類を選択してください。',
+				personal: '個人 (Microsoftアカウント)',
+				workSchool: '職場または学校 (任意の組織)',
+				tenant: '職場または学校 (特定の組織)',
+				tenantIdName: 'テナントID',
+				tenantIdDesc: 'サインイン先のEntra IDテナント (ディレクトリ) ID。',
+				tenantIdPlaceholder: '例: 11111111-1111-1111-1111-111111111111',
+				appFolderUnavailable: 'アプリフォルダーモードは職場または学校アカウントでは利用できません。',
+				reconnectRequired: ' この変更には再接続が必要です。',
+			},
 			accessMode: {
 				name: 'OneDriveアクセスモード',
 				appFolder: 'アプリフォルダ（推奨）',
@@ -312,6 +337,7 @@ export const ja = {
 				name: 'カスタムクライアントID',
 				desc: 'Azure ADアプリケーション（クライアント）ID',
 				helpPrefix: '',
+				requiredNote: ' 職場または学校アカウントでは必須です。',
 				helpLink: 'カスタムクライアントIDセットアップガイド',
 				helpSuffix: 'をREADMEで参照。',
 			},

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -56,6 +56,20 @@ export const pt = {
 			connectSuccess: 'Conectado com sucesso ao OneDrive',
 			connectFailed: 'Falha ao conectar ao OneDrive: {{message}}',
 			disconnectSuccess: 'Desconectado do OneDrive',
+			customClientIdRequired:
+				'Contas de trabalho ou escola exigem um ID de cliente personalizado. Consulte a documentação de configuração para registrar seu próprio aplicativo.',
+			tenantIdRequired: 'Um ID de locatário é necessário para o tipo de conta locatário.',
+			reconnectRequiredIdentityChanged: 'Configurações da conta alteradas. Por favor, reconecte-se ao OneDrive.',
+			accessModeSwitchedToFullAccess:
+				'O modo Pasta do aplicativo não está disponível para contas de trabalho ou escola. O modo de acesso foi alterado para Acesso completo.',
+			entra: {
+				conditionalAccessBlocked:
+					'A política da sua organização bloqueia este método de login. Contate seu administrador ou tente outro dispositivo.',
+				appNotAuthorized:
+					'Este aplicativo ainda não foi aprovado em sua organização. Peça a um administrador para aprovar o registro do aplicativo.',
+				accountTypeMismatch:
+					'A conta conectada não corresponde ao tipo de conta configurado. Verifique o tipo de conta nas configurações.',
+			},
 		},
 		sync: {
 			stateCleared: 'Estado de sincronização limpo. Executando sincronização completa...',
@@ -178,6 +192,18 @@ export const pt = {
 	settings: {
 		auth: {
 			heading: 'Autenticação',
+			accountType: {
+				name: 'Tipo de conta',
+				desc: 'Escolha com qual tipo de conta Microsoft você está se conectando.',
+				personal: 'Pessoal (conta Microsoft)',
+				workSchool: 'Trabalho ou escola (qualquer organização)',
+				tenant: 'Trabalho ou escola (organização específica)',
+				tenantIdName: 'ID do locatário',
+				tenantIdDesc: 'O ID do locatário (diretório) do Entra ID para autenticação.',
+				tenantIdPlaceholder: 'ex. 11111111-1111-1111-1111-111111111111',
+				appFolderUnavailable: 'O modo Pasta do aplicativo não está disponível para contas de trabalho ou escola.',
+				reconnectRequired: ' Esta alteração requer reconexão.',
+			},
 			accessMode: {
 				name: 'Modo de acesso OneDrive',
 				appFolder: 'Pasta do aplicativo (Recomendado)',
@@ -312,6 +338,7 @@ export const pt = {
 				name: 'ID de cliente personalizado',
 				desc: 'Seu ID de Aplicativo (cliente) Azure AD',
 				helpPrefix: 'Veja ',
+				requiredNote: ' Necessário para contas de trabalho ou escola.',
 				helpLink: 'Guia de configuração de ID de cliente personalizado',
 				helpSuffix: ' no README.',
 			},

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -58,6 +58,15 @@ export const zhCn = {
 			connectSuccess: '已连接到 OneDrive',
 			connectFailed: '连接 OneDrive 失败：{{message}}',
 			disconnectSuccess: '已断开 OneDrive 连接',
+			customClientIdRequired: '工作或学校账户需要自定义客户端 ID。请参阅设置文档以注册您自己的应用程序。',
+			tenantIdRequired: '租户账户类型需要租户 ID。',
+			reconnectRequiredIdentityChanged: '账户设置已更改，请重新连接 OneDrive。',
+			accessModeSwitchedToFullAccess: '工作或学校账户不支持应用文件夹模式，访问模式已切换为完全访问。',
+			entra: {
+				conditionalAccessBlocked: '您组织的策略阻止了此登录方式。请联系管理员，或尝试其他设备。',
+				appNotAuthorized: '该应用程序尚未在您的组织中获得批准。请让管理员批准该应用注册。',
+				accountTypeMismatch: '登录的账户与配置的账户类型不匹配，请检查设置中的账户类型。',
+			},
 		},
 		sync: {
 			stateCleared: '同步状态已清除，正在执行完整同步...',
@@ -177,6 +186,18 @@ export const zhCn = {
 	settings: {
 		auth: {
 			heading: '授权',
+			accountType: {
+				name: '账户类型',
+				desc: '选择要连接的 Microsoft 账户类型。',
+				personal: '个人（Microsoft 账户）',
+				workSchool: '工作或学校（任意组织）',
+				tenant: '工作或学校（指定组织）',
+				tenantIdName: '租户 ID',
+				tenantIdDesc: '要登录的 Entra ID 租户（目录）ID。',
+				tenantIdPlaceholder: '例如：11111111-1111-1111-1111-111111111111',
+				appFolderUnavailable: '工作或学校账户不支持应用文件夹模式。',
+				reconnectRequired: ' 更改此项需要重新连接。',
+			},
 			accessMode: {
 				name: 'OneDrive 访问模式',
 				appFolder: '应用文件夹（推荐）',
@@ -312,6 +333,7 @@ export const zhCn = {
 				toggleName: '使用自定义客户端 ID',
 				toggleDesc: '使用你自己的 Azure AD 应用注册信息。设置方法见 README。',
 				name: '自定义客户端 ID',
+				requiredNote: '（工作或学校账户为必填项）',
 				desc: '你的 Azure AD Application (client) ID',
 				helpPrefix: '查看 README 中的 ',
 				helpLink: '自定义客户端 ID 设置指南',

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@
 
 import { Platform, Plugin, Notice, TFile } from 'obsidian';
 import {
+	AccountType,
 	PluginSettings,
 	DEFAULT_SETTINGS,
 	DEFAULT_EXPERIMENTAL_SETTINGS,
@@ -12,7 +13,7 @@ import {
 	OneDriveAccessMode,
 	OneDriveItem,
 } from './types';
-import { DEFAULT_ONEDRIVE_CLIENT_ID } from './constants';
+import { DEFAULT_ONEDRIVE_CLIENT_ID, resolveOAuthEndpoints, resolveOAuthScopes } from './constants';
 import { logger, LogLevel } from './utils/logger';
 import { shouldSyncVaultPath } from './utils/pathUtils';
 import {
@@ -88,7 +89,10 @@ export default class OneDriveSyncPlugin extends Plugin {
 
 	// Core components
 	private tokenStorage: TokenStorage;
-	private deviceCodeClient: DeviceCodeFlowClient;
+	// Undefined when the configured identity can't be resolved (e.g. tenant
+	// account type with no usable tenant ID). We fail closed rather than fall
+	// back to a different authority.
+	private deviceCodeClient?: DeviceCodeFlowClient;
 	private authProvider?: OneDriveAuthProvider;
 	private oneDriveClient?: OneDriveClient;
 	private fileOps?: FileOperations;
@@ -139,11 +143,18 @@ export default class OneDriveSyncPlugin extends Plugin {
 		}
 		this.syncStateManager.loadState(this.settings.syncState);
 
-		// Initialize device code client with appropriate client ID and access mode
-		const clientId = this.settings.useCustomClientId
-			? this.settings.customClientId || DEFAULT_ONEDRIVE_CLIENT_ID
-			: DEFAULT_ONEDRIVE_CLIENT_ID;
-		this.deviceCodeClient = new DeviceCodeFlowClient(clientId, this.settings.accessMode);
+		// A misconfigured identity must not stop the plugin from loading — it leaves
+		// the client unset, and the error surfaces when the user connects or syncs.
+		try {
+			this.deviceCodeClient = this.buildDeviceCodeClient();
+		} catch (error) {
+			logger.error('Cannot build an auth client from the current account settings:', error);
+			new Notice(
+				t('notices.auth.connectFailed', {
+					message: error instanceof Error ? error.message : t('notices.common.unknownError'),
+				})
+			);
+		}
 
 		// Initialize authenticated components if we have tokens
 		if (this.tokenStorage.hasTokens()) {
@@ -275,6 +286,14 @@ export default class OneDriveSyncPlugin extends Plugin {
 	 */
 	private async initializeAuthenticatedComponents() {
 		logger.info(`Initializing authenticated components (mode: ${this.settings.accessMode})`);
+
+		if (!this.deviceCodeClient) {
+			// No usable authority for the configured identity — refreshing a token
+			// against the wrong one would fail with an opaque AADSTS error.
+			logger.error('Cannot initialize authenticated components: no auth client for the current settings');
+			new Notice(t('notices.auth.clientInitFailed'));
+			return;
+		}
 
 		try {
 			// Initialize auth provider
@@ -426,6 +445,74 @@ export default class OneDriveSyncPlugin extends Plugin {
 		}
 	}
 
+	private buildDeviceCodeClient(): DeviceCodeFlowClient {
+		// accountType is normalized in loadSettings(), so it is always one of the
+		// three known values here.
+		const accountType = this.settings.accountType;
+		// Personal accounts opt into a custom client ID via the toggle; work and
+		// school accounts always require one, since the bundled registration
+		// only serves personal accounts.
+		const effectiveCustomClientId =
+			accountType !== 'personal' || this.settings.useCustomClientId
+				? this.settings.customClientId
+				: undefined;
+		const clientId = effectiveCustomClientId || DEFAULT_ONEDRIVE_CLIENT_ID;
+
+		// Deliberately not caught: presenting an org identity (and its client ID)
+		// to the consumer authority yields an opaque AADSTS failure and a forced
+		// re-auth. Callers surface the real configuration error instead.
+		const endpoints = resolveOAuthEndpoints(accountType, this.settings.tenantId);
+
+		const scopes = resolveOAuthScopes(accountType, this.settings.accessMode);
+
+		return new DeviceCodeFlowClient(endpoints, scopes, clientId);
+	}
+
+	/**
+	 * Discard stored credentials because the configured identity (account type,
+	 * tenant ID, or client ID) changed. Refresh tokens are bound to the
+	 * authority and client that issued them, so a stale token must never be
+	 * presented to a different one.
+	 */
+	async invalidateCredentialsForIdentityChange(): Promise<void> {
+		if (!this.tokenStorage.hasTokens() && !this.settings.connectedUser) {
+			return;
+		}
+
+		logger.info('Identity configuration changed — clearing stored credentials');
+
+		this.deviceCodeClient?.cancelPolling();
+		if (this.eventManager) {
+			this.eventManager.stopListening();
+		}
+
+		this.tokenStorage.clearTokens();
+		this.settings.tokens = undefined;
+		this.settings.connectedUser = undefined;
+
+		// Drive and item IDs are scoped to the previous identity's drive, and the
+		// sync state holds a delta link plus remote item IDs from it. Reusing
+		// either against the new account means 403/404 on every request, or files
+		// skipped as already-uploaded. Clear them like disconnect() does.
+		this.settings.remoteDriveId = undefined;
+		this.settings.remoteItemId = undefined;
+		this.settings.remoteRootName = undefined;
+		this.settings.remoteRootPath = undefined;
+		this.settings.remoteRelativePathInShared = undefined;
+		this.syncStateManager.clearState();
+
+		this.authProvider = undefined;
+		this.oneDriveClient = undefined;
+		this.fileOps = undefined;
+		this.syncEngine = undefined;
+		this.eventManager = undefined;
+
+		await this.saveSettings();
+		this.updateStatusBar();
+
+		new Notice(t('notices.auth.reconnectRequiredIdentityChanged'));
+	}
+
 	/**
 	 * Authenticate with OneDrive using Device Code Flow
 	 */
@@ -433,14 +520,18 @@ export default class OneDriveSyncPlugin extends Plugin {
 		logger.info('Starting authentication flow');
 
 		try {
-			// Cancel any in-progress polling from a previous auth attempt
-			this.deviceCodeClient.cancelPolling();
+			if (this.settings.accountType !== 'personal' && !this.settings.customClientId?.trim()) {
+				throw new Error(t('notices.auth.customClientIdRequired'));
+			}
+			if (this.settings.accountType === 'tenant' && !this.settings.tenantId?.trim()) {
+				throw new Error(t('notices.auth.tenantIdRequired'));
+			}
 
-			// Recreate the device code client so it uses the current access mode
-			const clientId = this.settings.useCustomClientId
-				? this.settings.customClientId || DEFAULT_ONEDRIVE_CLIENT_ID
-				: DEFAULT_ONEDRIVE_CLIENT_ID;
-			this.deviceCodeClient = new DeviceCodeFlowClient(clientId, this.settings.accessMode);
+			// Cancel any in-progress polling from a previous auth attempt
+			this.deviceCodeClient?.cancelPolling();
+
+			// Recreate the client so it picks up the current identity settings
+			this.deviceCodeClient = this.buildDeviceCodeClient();
 			logger.info(`Authenticating with access mode: ${this.settings.accessMode}`);
 
 			let modalClosed = false;
@@ -495,7 +586,9 @@ export default class OneDriveSyncPlugin extends Plugin {
 			if (this.eventManager && this.isSyncConfigured()) {
 				this.eventManager.startListening();
 				this.eventManager.startPeriodicSync(this.settings.syncInterval || 0);
-			} else if (this.settings.accessMode === OneDriveAccessMode.APP_FOLDER) {
+			} else if (!this.isSyncConfigured()) {
+				// Whatever the access mode, nothing will ever sync until a target
+				// is chosen — say so rather than reporting a bare success.
 				new Notice(t('notices.sync.selectFolderFirst'));
 			}
 
@@ -522,7 +615,7 @@ export default class OneDriveSyncPlugin extends Plugin {
 		logger.info('Disconnecting from OneDrive');
 
 		// Cancel any in-progress auth polling
-		this.deviceCodeClient.cancelPolling();
+		this.deviceCodeClient?.cancelPolling();
 
 		// Stop event manager
 		if (this.eventManager) {
@@ -1025,6 +1118,8 @@ export default class OneDriveSyncPlugin extends Plugin {
 			loaded
 		);
 
+		this.normalizeIdentitySettings();
+
 		// Migrate legacy enableDebugLogging boolean → logLevel string
 		const raw = this.settings as unknown as Record<string, unknown>;
 		if ('enableDebugLogging' in raw) {
@@ -1044,6 +1139,34 @@ export default class OneDriveSyncPlugin extends Plugin {
 					this.settings.connectedUser || this.settings.appFolderSubpath
 				);
 			}
+		}
+	}
+
+	/**
+	 * Single owner of the identity-related settings invariants, applied once on
+	 * load so the rest of the plugin can trust the values:
+	 * - accountType is one of the three known values (`Object.assign` copies a
+	 *   null or bogus value straight over the default)
+	 * - tenantId and customClientId are trimmed, or undefined when blank
+	 * - work/school and tenant accounts are never left in App Folder mode, which
+	 *   Entra does not offer them — the dropdown hides the option, so a stored
+	 *   value would otherwise show one thing and request another
+	 */
+	normalizeIdentitySettings(): void {
+		const validAccountTypes: AccountType[] = ['personal', 'work-school', 'tenant'];
+		if (!validAccountTypes.includes(this.settings.accountType)) {
+			this.settings.accountType = DEFAULT_SETTINGS.accountType;
+		}
+
+		this.settings.tenantId = this.settings.tenantId?.trim() || undefined;
+		this.settings.customClientId = this.settings.customClientId?.trim() || undefined;
+
+		if (
+			this.settings.accountType !== 'personal' &&
+			this.settings.accessMode === OneDriveAccessMode.APP_FOLDER
+		) {
+			logger.info('App Folder mode is unavailable for this account type — using Full Access');
+			this.settings.accessMode = OneDriveAccessMode.FULL_ACCESS;
 		}
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -284,6 +284,14 @@ export enum OneDriveAccessMode {
 	FULL_ACCESS = 'full-access', // Access to all OneDrive files
 }
 
+/**
+ * Which Microsoft identity authority to sign in against.
+ * - `personal`: consumer Microsoft account (`/consumers/`)
+ * - `work-school`: any Entra ID work or school account (`/organizations/`)
+ * - `tenant`: one named Entra ID tenant (`/{tenantId}/`)
+ */
+export type AccountType = 'personal' | 'work-school' | 'tenant';
+
 /** Experimental settings — performance tuning and unstable features */
 export interface ExperimentalSettings {
 	skipFolderChecks: boolean; // Skip folder existence checks before uploads (OneDrive auto-creates)
@@ -301,6 +309,8 @@ export const DEFAULT_EXPERIMENTAL_SETTINGS: ExperimentalSettings = {
 
 export interface PluginSettings {
 	// Authentication
+	accountType: AccountType;
+	tenantId?: string; // Required when accountType is 'tenant'
 	useCustomClientId: boolean;
 	customClientId?: string;
 	tokens?: StoredTokens;
@@ -345,6 +355,8 @@ export interface PluginSettings {
 
 export const DEFAULT_SETTINGS: PluginSettings = {
 	// Authentication
+	accountType: 'personal',
+	tenantId: undefined,
 	useCustomClientId: false,
 	customClientId: undefined,
 	tokens: undefined,

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -111,6 +111,17 @@ export class OneDriveSettingTab extends PluginSettingTab {
 						},
 					},
 					{
+						// Required for work and school accounts, so it belongs with the
+						// identity settings rather than under Advanced, where an
+						// optional personal-account override lives.
+						name: t('settings.advanced.customClientId.name'),
+						desc: t('settings.advanced.customClientId.desc'),
+						visible: () => this.plugin.settings.accountType !== 'personal',
+						render: (setting) => {
+							this.renderCustomClientIdSetting(setting);
+						},
+					},
+					{
 						name: t('settings.auth.accessMode.name'),
 						desc: t('settings.auth.accessMode.fullAccessDesc'),
 						render: (setting) => {
@@ -327,8 +338,11 @@ export class OneDriveSettingTab extends PluginSettingTab {
 					{
 						name: t('settings.advanced.customClientId.name'),
 						desc: t('settings.advanced.customClientId.desc'),
+						// Personal accounts only — work and school accounts render this
+						// field in the Authentication group, where it is required.
 						visible: () =>
-							this.plugin.settings.useCustomClientId || this.plugin.settings.accountType !== 'personal',
+							this.plugin.settings.accountType === 'personal' &&
+							this.plugin.settings.useCustomClientId,
 						render: (setting) => {
 							this.renderCustomClientIdSetting(setting);
 						},
@@ -919,6 +933,12 @@ export class OneDriveSettingTab extends PluginSettingTab {
 			this.renderTenantIdSetting(new Setting(containerEl));
 		}
 
+		// Client ID — required for work and school accounts, so it sits with the
+		// identity settings instead of under Advanced
+		if (this.plugin.settings.accountType !== 'personal') {
+			this.renderCustomClientIdSetting(new Setting(containerEl));
+		}
+
 		// Access mode
 		this.renderAccessModeSetting(new Setting(containerEl));
 
@@ -1322,8 +1342,9 @@ export class OneDriveSettingTab extends PluginSettingTab {
 				})
 			);
 
-		// Toggle is personal-only; org accounts always need a custom client ID,
-		// so the field below renders unconditionally for them
+		// Personal accounts only: an optional override behind a toggle. Work and
+		// school accounts require a client ID and render it in the Authentication
+		// section instead.
 		if (this.plugin.settings.accountType === 'personal') {
 			new Setting(containerEl)
 				.setName(t('settings.advanced.customClientId.toggleName'))
@@ -1335,10 +1356,10 @@ export class OneDriveSettingTab extends PluginSettingTab {
 						this.renderSettings();
 					})
 				);
-		}
 
-		if (this.plugin.settings.useCustomClientId || this.plugin.settings.accountType !== 'personal') {
-			this.renderCustomClientIdSetting(new Setting(containerEl));
+			if (this.plugin.settings.useCustomClientId) {
+				this.renderCustomClientIdSetting(new Setting(containerEl));
+			}
 		}
 	}
 

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -10,6 +10,7 @@ import {
 	Setting,
 	Notice,
 	type PluginManifest,
+	type TextComponent,
 	type SettingDefinitionItem,
 } from 'obsidian';
 import {
@@ -69,6 +70,8 @@ interface OneDrivePlugin extends Plugin {
 	onAppFolderSubpathChanged(subpath: string): Promise<void>;
 	getSyncStatusInfo(): SyncStatusInfo;
 	getExperimentalSetting<K extends keyof ExperimentalSettings>(key: K): ExperimentalSettings[K];
+	invalidateCredentialsForIdentityChange(): Promise<void>;
+	normalizeIdentitySettings(): void;
 }
 
 /**
@@ -92,6 +95,21 @@ export class OneDriveSettingTab extends PluginSettingTab {
 				type: 'group',
 				heading: t('settings.auth.heading'),
 				items: [
+					{
+						name: t('settings.auth.accountType.name'),
+						desc: t('settings.auth.accountType.desc'),
+						render: (setting) => {
+							this.renderAccountTypeSetting(setting);
+						},
+					},
+					{
+						name: t('settings.auth.accountType.tenantIdName'),
+						desc: t('settings.auth.accountType.tenantIdDesc'),
+						visible: () => this.plugin.settings.accountType === 'tenant',
+						render: (setting) => {
+							this.renderTenantIdSetting(setting);
+						},
+					},
 					{
 						name: t('settings.auth.accessMode.name'),
 						desc: t('settings.auth.accessMode.fullAccessDesc'),
@@ -300,6 +318,7 @@ export class OneDriveSettingTab extends PluginSettingTab {
 					{
 						name: t('settings.advanced.customClientId.toggleName'),
 						desc: t('settings.advanced.customClientId.toggleDesc'),
+						visible: () => this.plugin.settings.accountType === 'personal',
 						control: {
 							type: 'toggle',
 							key: 'useCustomClientId',
@@ -308,7 +327,8 @@ export class OneDriveSettingTab extends PluginSettingTab {
 					{
 						name: t('settings.advanced.customClientId.name'),
 						desc: t('settings.advanced.customClientId.desc'),
-						visible: () => this.plugin.settings.useCustomClientId,
+						visible: () =>
+							this.plugin.settings.useCustomClientId || this.plugin.settings.accountType !== 'personal',
 						render: (setting) => {
 							this.renderCustomClientIdSetting(setting);
 						},
@@ -496,30 +516,112 @@ export class OneDriveSettingTab extends PluginSettingTab {
 		await this.plugin.saveSettings();
 	}
 
+	private isAppFolderAllowed(): boolean {
+		return this.plugin.settings.accountType === 'personal';
+	}
+
+	private renderAccountTypeSetting(setting: Setting): void {
+		const isConnected = !!this.plugin.settings.connectedUser;
+		const desc = isConnected
+			? t('settings.auth.accountType.desc') + t('settings.auth.accountType.reconnectRequired')
+			: t('settings.auth.accountType.desc');
+
+		setting
+			.setName(t('settings.auth.accountType.name'))
+			.setDesc(desc)
+			.addDropdown((dropdown) =>
+				dropdown
+					.addOption('personal', t('settings.auth.accountType.personal'))
+					.addOption('work-school', t('settings.auth.accountType.workSchool'))
+					.addOption('tenant', t('settings.auth.accountType.tenant'))
+					.setValue(this.plugin.settings.accountType)
+					.onChange(async (value) => {
+						this.plugin.settings.accountType = value as PluginSettings['accountType'];
+						const wasAppFolder = this.plugin.settings.accessMode === OneDriveAccessMode.APP_FOLDER;
+						this.plugin.normalizeIdentitySettings();
+						if (wasAppFolder && this.plugin.settings.accessMode !== OneDriveAccessMode.APP_FOLDER) {
+							new Notice(t('notices.auth.accessModeSwitchedToFullAccess'));
+						}
+						await this.plugin.saveSettings();
+						await this.plugin.invalidateCredentialsForIdentityChange();
+						this.refreshSettingsUi();
+					})
+			);
+	}
+
+	private renderTenantIdSetting(setting: Setting): void {
+		const isConnected = !!this.plugin.settings.connectedUser;
+		const desc = isConnected
+			? t('settings.auth.accountType.tenantIdDesc') + t('settings.auth.accountType.reconnectRequired')
+			: t('settings.auth.accountType.tenantIdDesc');
+
+		setting
+			.setName(t('settings.auth.accountType.tenantIdName'))
+			.setDesc(desc)
+			.addText((text) => {
+				text.setPlaceholder(t('settings.auth.accountType.tenantIdPlaceholder'))
+					.setValue(this.plugin.settings.tenantId || '')
+					.onChange(async (value) => {
+						this.plugin.settings.tenantId = value.trim() || undefined;
+						await this.plugin.saveSettings();
+					});
+				this.invalidateCredentialsOnCommit(text, () => this.plugin.settings.tenantId);
+			});
+	}
+
+	/**
+	 * Discard credentials when an identity field is *finished* being edited.
+	 *
+	 * Obsidian fires onChange per keystroke, so invalidating there would wipe the
+	 * user's tokens on the first character of a one-character correction. Wait
+	 * for the field to lose focus (or Enter), and only act if the committed value
+	 * actually differs from the one the current tokens were issued against.
+	 */
+	private invalidateCredentialsOnCommit(text: TextComponent, read: () => string | undefined): void {
+		let committedValue = read();
+
+		const commit = async () => {
+			const currentValue = read();
+			if (currentValue === committedValue) return;
+			committedValue = currentValue;
+			await this.plugin.invalidateCredentialsForIdentityChange();
+			this.refreshSettingsUi();
+		};
+
+		text.inputEl.addEventListener('blur', () => void commit());
+		text.inputEl.addEventListener('keydown', (event) => {
+			if (event.key === 'Enter') void commit();
+		});
+	}
+
 	private renderAccessModeSetting(setting: Setting): void {
 		const isConnected = !!this.plugin.settings.connectedUser;
+		const appFolderAllowed = this.isAppFolderAllowed();
 		const modeDesc =
 			this.plugin.settings.accessMode === OneDriveAccessMode.FULL_ACCESS
 				? t('settings.auth.accessMode.fullAccessDesc')
 				: t('settings.auth.accessMode.appFolderDesc');
-		const descWithWarning = isConnected
-			? modeDesc + t('settings.auth.accessMode.reconnectRequired')
-			: modeDesc;
+		let desc = appFolderAllowed ? modeDesc : `${modeDesc} ${t('settings.auth.accountType.appFolderUnavailable')}`;
+		if (isConnected) {
+			desc += t('settings.auth.accessMode.reconnectRequired');
+		}
 
 		setting
 			.setName(t('settings.auth.accessMode.name'))
-			.setDesc(descWithWarning)
-			.addDropdown((dropdown) =>
+			.setDesc(desc)
+			.addDropdown((dropdown) => {
+				if (appFolderAllowed) {
+					dropdown.addOption(OneDriveAccessMode.APP_FOLDER, t('settings.auth.accessMode.appFolder'));
+				}
 				dropdown
-					.addOption(OneDriveAccessMode.APP_FOLDER, t('settings.auth.accessMode.appFolder'))
 					.addOption(OneDriveAccessMode.FULL_ACCESS, t('settings.auth.accessMode.fullAccess'))
 					.setValue(this.plugin.settings.accessMode)
 					.onChange(async (value) => {
 						this.plugin.settings.accessMode = value as OneDriveAccessMode;
 						await this.plugin.saveSettings();
 						this.refreshSettingsUi();
-					})
-			);
+					});
+			});
 	}
 
 	private renderConnectionStatusSetting(setting: Setting): void {
@@ -761,18 +863,23 @@ export class OneDriveSettingTab extends PluginSettingTab {
 	}
 
 	private renderCustomClientIdSetting(setting: Setting): void {
+		const isRequired = this.plugin.settings.accountType !== 'personal';
+		const desc = isRequired
+			? t('settings.advanced.customClientId.desc') + t('settings.advanced.customClientId.requiredNote')
+			: t('settings.advanced.customClientId.desc');
+
 		setting
 			.setName(t('settings.advanced.customClientId.name'))
-			.setDesc(t('settings.advanced.customClientId.desc'))
-			.addText((text) =>
-				text
-					.setPlaceholder(DEFAULT_ONEDRIVE_CLIENT_ID)
+			.setDesc(desc)
+			.addText((text) => {
+				text.setPlaceholder(DEFAULT_ONEDRIVE_CLIENT_ID)
 					.setValue(this.plugin.settings.customClientId || '')
 					.onChange(async (value) => {
-						this.plugin.settings.customClientId = value;
+						this.plugin.settings.customClientId = value.trim() || undefined;
 						await this.plugin.saveSettings();
-					})
-			);
+					});
+				this.invalidateCredentialsOnCommit(text, () => this.plugin.settings.customClientId);
+			});
 
 		setting.descEl.appendText(` ${t('settings.advanced.customClientId.helpPrefix')}`);
 		setting.descEl.createEl('a', {
@@ -805,30 +912,15 @@ export class OneDriveSettingTab extends PluginSettingTab {
 	private displayAuthSection(containerEl: HTMLElement): void {
 		new Setting(containerEl).setName(t('settings.auth.heading')).setHeading();
 
-		// Access mode — first setting in this section
-		const isConnected = !!this.plugin.settings.connectedUser;
-		const modeDesc =
-			this.plugin.settings.accessMode === OneDriveAccessMode.FULL_ACCESS
-				? t('settings.auth.accessMode.fullAccessDesc')
-				: t('settings.auth.accessMode.appFolderDesc');
-		const descWithWarning = isConnected
-			? modeDesc + t('settings.auth.accessMode.reconnectRequired')
-			: modeDesc;
+		// Account type — before access mode, which it constrains
+		this.renderAccountTypeSetting(new Setting(containerEl));
 
-		new Setting(containerEl)
-			.setName(t('settings.auth.accessMode.name'))
-			.setDesc(descWithWarning)
-			.addDropdown((dropdown) =>
-				dropdown
-					.addOption(OneDriveAccessMode.APP_FOLDER, t('settings.auth.accessMode.appFolder'))
-					.addOption(OneDriveAccessMode.FULL_ACCESS, t('settings.auth.accessMode.fullAccess'))
-					.setValue(this.plugin.settings.accessMode)
-					.onChange(async (value) => {
-						this.plugin.settings.accessMode = value as OneDriveAccessMode;
-						await this.plugin.saveSettings();
-						this.renderSettings();
-					})
-			);
+		if (this.plugin.settings.accountType === 'tenant') {
+			this.renderTenantIdSetting(new Setting(containerEl));
+		}
+
+		// Access mode
+		this.renderAccessModeSetting(new Setting(containerEl));
 
 		// Connection status
 		const statusSetting = new Setting(containerEl).setName(
@@ -1230,42 +1322,23 @@ export class OneDriveSettingTab extends PluginSettingTab {
 				})
 			);
 
-		// Custom client ID toggle
-		new Setting(containerEl)
-			.setName(t('settings.advanced.customClientId.toggleName'))
-			.setDesc(t('settings.advanced.customClientId.toggleDesc'))
-			.addToggle((toggle) =>
-				toggle.setValue(this.plugin.settings.useCustomClientId).onChange(async (value) => {
-					this.plugin.settings.useCustomClientId = value;
-					await this.plugin.saveSettings();
-					this.renderSettings();
-				})
-			);
-
-		if (this.plugin.settings.useCustomClientId) {
+		// Toggle is personal-only; org accounts always need a custom client ID,
+		// so the field below renders unconditionally for them
+		if (this.plugin.settings.accountType === 'personal') {
 			new Setting(containerEl)
-				.setName(t('settings.advanced.customClientId.name'))
-				.setDesc(t('settings.advanced.customClientId.desc'))
-				.addText((text) =>
-					text
-						.setPlaceholder(DEFAULT_ONEDRIVE_CLIENT_ID)
-						.setValue(this.plugin.settings.customClientId || '')
-						.onChange(async (value) => {
-							this.plugin.settings.customClientId = value;
-							await this.plugin.saveSettings();
-						})
+				.setName(t('settings.advanced.customClientId.toggleName'))
+				.setDesc(t('settings.advanced.customClientId.toggleDesc'))
+				.addToggle((toggle) =>
+					toggle.setValue(this.plugin.settings.useCustomClientId).onChange(async (value) => {
+						this.plugin.settings.useCustomClientId = value;
+						await this.plugin.saveSettings();
+						this.renderSettings();
+					})
 				);
+		}
 
-			const helpDiv = containerEl.createDiv({
-				cls: 'setting-item-description onedrive-sync-settings-help',
-			});
-			helpDiv.appendText(t('settings.advanced.customClientId.helpPrefix'));
-			helpDiv.createEl('a', {
-				text: t('settings.advanced.customClientId.helpLink'),
-				href: 'https://github.com/jeffsteinbok/obsidian-onedrive#custom-client-id',
-				attr: { target: '_blank' },
-			});
-			helpDiv.appendText(t('settings.advanced.customClientId.helpSuffix'));
+		if (this.plugin.settings.useCustomClientId || this.plugin.settings.accountType !== 'personal') {
+			this.renderCustomClientIdSetting(new Setting(containerEl));
 		}
 	}
 

--- a/tests/unit/api/oneDriveClient.test.ts
+++ b/tests/unit/api/oneDriveClient.test.ts
@@ -79,6 +79,21 @@ describe('OneDriveClient', () => {
 			expect(fullAccessClient.buildEndpoint('folder name/file#.md')).toBe(`/me/drive/root:/${encoded}`);
 		});
 
+		it('never emits an app-folder (approot) endpoint in Full Access mode — required for work/school accounts', () => {
+			// Work and school accounts are restricted to Full Access mode (Microsoft
+			// Graph does not offer Files.ReadWrite.AppFolder to them), so
+			// buildEndpoint() must never fall back to the approot shape here.
+			const fullAccessClient = new OneDriveClient(mockAuthProvider as any, OneDriveAccessMode.FULL_ACCESS);
+			const paths = ['', 'Notes', 'folder/sub folder/file#.md'];
+			const suffixes: (string | undefined)[] = [undefined, 'children', 'delta'];
+
+			for (const path of paths) {
+				for (const suffix of suffixes) {
+					expect(fullAccessClient.buildEndpoint(path, suffix)).not.toContain('approot');
+				}
+			}
+		});
+
 		it('builds the shared drive root endpoint without a suffix', () => {
 			client.setRemoteDrive('drive-123', 'item-456', 'Shared');
 			expect(client.buildEndpoint('')).toBe('/drives/drive-123/items/item-456');

--- a/tests/unit/auth/deviceCodeFlow.test.ts
+++ b/tests/unit/auth/deviceCodeFlow.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockRequestUrl } from '../../setup';
+import { DeviceCodeFlowClient } from '../../../src/auth/deviceCodeFlow';
+import { resolveOAuthEndpoints } from '../../../src/constants';
+import { AuthenticationError } from '../../../src/types';
+
+const jsonResponse = (status: number, json: unknown) => ({
+	status,
+	json,
+	text: JSON.stringify(json),
+});
+
+describe('DeviceCodeFlowClient', () => {
+	beforeEach(() => {
+		mockRequestUrl.mockReset();
+	});
+
+	it('requests a device code from the injected endpoint using the injected scopes and client ID', async () => {
+		const endpoints = resolveOAuthEndpoints('tenant', 'my-tenant-id');
+		const scopes = ['User.Read', 'Files.ReadWrite', 'offline_access'];
+		mockRequestUrl.mockResolvedValue(
+			jsonResponse(200, {
+				device_code: 'dc',
+				user_code: 'ABCD-EFGH',
+				verification_uri: 'https://microsoft.com/devicelogin',
+				expires_in: 900,
+				interval: 5,
+			})
+		);
+
+		const client = new DeviceCodeFlowClient(endpoints, scopes, 'custom-client-id');
+		await client.requestDeviceCode();
+
+		expect(mockRequestUrl).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: 'https://login.microsoftonline.com/my-tenant-id/oauth2/v2.0/devicecode',
+				body: expect.stringContaining('client_id=custom-client-id'),
+			})
+		);
+		const call = mockRequestUrl.mock.calls[0][0] as { body: string };
+		expect(call.body).toContain('scope=User.Read+Files.ReadWrite+offline_access');
+	});
+
+	it('polls the injected token endpoint and returns tokens on success', async () => {
+		const endpoints = resolveOAuthEndpoints('work-school', undefined);
+		mockRequestUrl.mockResolvedValue(
+			jsonResponse(200, { access_token: 'at', refresh_token: 'rt', expires_in: 3600, token_type: 'Bearer', scope: 'x' })
+		);
+
+		const client = new DeviceCodeFlowClient(endpoints, ['User.Read'], 'client-id');
+		const result = await client.pollForToken('device-code', 1, 60);
+
+		expect(result.access_token).toBe('at');
+		expect(mockRequestUrl).toHaveBeenCalledWith(
+			expect.objectContaining({ url: 'https://login.microsoftonline.com/organizations/oauth2/v2.0/token' })
+		);
+	});
+
+	it('maps a Conditional Access rejection to a plain-language message and stops polling', async () => {
+		const endpoints = resolveOAuthEndpoints('tenant', 'tenant-id');
+		mockRequestUrl.mockResolvedValue(
+			jsonResponse(400, {
+				error: 'invalid_grant',
+				error_description: 'AADSTS53003: Access has been blocked by Conditional Access policies.',
+			})
+		);
+
+		const client = new DeviceCodeFlowClient(endpoints, ['User.Read'], 'client-id');
+
+		await expect(client.pollForToken('device-code', 1, 60)).rejects.toMatchObject({
+			message: expect.stringMatching(/organization/i),
+		});
+		expect(mockRequestUrl).toHaveBeenCalledTimes(1);
+	});
+
+	it('maps an unapproved application rejection to an administrator-approval message', async () => {
+		const endpoints = resolveOAuthEndpoints('tenant', 'tenant-id');
+		mockRequestUrl.mockResolvedValue(
+			jsonResponse(400, {
+				error: 'unauthorized_client',
+				error_description: 'AADSTS700016: Application not found in directory.',
+			})
+		);
+
+		const client = new DeviceCodeFlowClient(endpoints, ['User.Read'], 'client-id');
+
+		await expect(client.pollForToken('device-code', 1, 60)).rejects.toMatchObject({
+			message: expect.stringMatching(/administrator/i),
+		});
+	});
+
+	it('maps an account-type mismatch rejection to a message naming the mismatch', async () => {
+		const endpoints = resolveOAuthEndpoints('tenant', 'tenant-id');
+		mockRequestUrl.mockResolvedValue(
+			jsonResponse(400, {
+				error: 'invalid_grant',
+				error_description: 'AADSTS50020: User account from identity provider does not exist in tenant.',
+			})
+		);
+
+		const client = new DeviceCodeFlowClient(endpoints, ['User.Read'], 'client-id');
+
+		await expect(client.pollForToken('device-code', 1, 60)).rejects.toMatchObject({
+			message: expect.stringMatching(/does not match/i),
+		});
+	});
+
+	it('still handles authorization_pending without treating it as a fatal error', async () => {
+		const endpoints = resolveOAuthEndpoints('personal', undefined);
+		mockRequestUrl
+			.mockResolvedValueOnce(jsonResponse(400, { error: 'authorization_pending' }))
+			.mockResolvedValueOnce(
+				jsonResponse(200, { access_token: 'at', refresh_token: 'rt', expires_in: 3600, token_type: 'Bearer', scope: 'x' })
+			);
+
+		const client = new DeviceCodeFlowClient(endpoints, ['User.Read'], 'client-id');
+		const onPending = vi.fn();
+		const result = await client.pollForToken('device-code', 0, 60, onPending);
+
+		expect(result.access_token).toBe('at');
+		expect(onPending).toHaveBeenCalled();
+	});
+
+	it('refreshes a token using the injected token endpoint', async () => {
+		const endpoints = resolveOAuthEndpoints('personal', undefined);
+		mockRequestUrl.mockResolvedValue(
+			jsonResponse(200, { access_token: 'new-at', expires_in: 3600, token_type: 'Bearer', scope: 'x' })
+		);
+
+		const client = new DeviceCodeFlowClient(endpoints, ['User.Read'], 'client-id');
+		const result = await client.refreshToken('old-rt');
+
+		expect(result.access_token).toBe('new-at');
+		expect(mockRequestUrl).toHaveBeenCalledWith(
+			expect.objectContaining({ url: 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token' })
+		);
+	});
+
+	it('maps an Entra rejection from the device code request itself', async () => {
+		const endpoints = resolveOAuthEndpoints('tenant', 'tenant-id');
+		mockRequestUrl.mockResolvedValue(
+			jsonResponse(400, {
+				error: 'unauthorized_client',
+				error_description: 'AADSTS700016: Application not found in directory.',
+			})
+		);
+
+		const client = new DeviceCodeFlowClient(endpoints, ['User.Read'], 'client-id');
+
+		await expect(client.requestDeviceCode()).rejects.toMatchObject({
+			message: expect.stringMatching(/administrator/i),
+		});
+		// The mapped message must not be buried behind the generic prefix
+		await expect(client.requestDeviceCode()).rejects.toMatchObject({
+			message: expect.not.stringContaining('Failed to request device code'),
+		});
+		expect(mockRequestUrl).toHaveBeenCalledWith(expect.objectContaining({ throw: false }));
+	});
+
+	it('does not misclassify a longer AADSTS code that shares a prefix', async () => {
+		const endpoints = resolveOAuthEndpoints('tenant', 'tenant-id');
+		mockRequestUrl.mockResolvedValue(
+			jsonResponse(400, {
+				error: 'invalid_grant',
+				error_description: 'AADSTS530032: Something unrelated to Conditional Access device policy.',
+			})
+		);
+
+		const client = new DeviceCodeFlowClient(endpoints, ['User.Read'], 'client-id');
+
+		await expect(client.pollForToken('device-code', 1, 60)).rejects.toMatchObject({
+			message: expect.stringContaining('AADSTS530032'),
+		});
+	});
+
+	it('throws AuthenticationError instances from pollForToken rejections', async () => {
+		const endpoints = resolveOAuthEndpoints('personal', undefined);
+		mockRequestUrl.mockResolvedValue(jsonResponse(400, { error: 'access_denied' }));
+
+		const client = new DeviceCodeFlowClient(endpoints, ['User.Read'], 'client-id');
+		await expect(client.pollForToken('device-code', 1, 60)).rejects.toBeInstanceOf(AuthenticationError);
+	});
+});

--- a/tests/unit/constants.test.ts
+++ b/tests/unit/constants.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+	resolveOAuthEndpoints,
+	resolveOAuthScopes,
+	OAUTH_SCOPES_APP_FOLDER,
+	OAUTH_SCOPES_FULL_ACCESS,
+	OAUTH_SCOPES_WORK_SCHOOL,
+} from '../../src/constants';
+import { OneDriveAccessMode } from '../../src/types';
+
+describe('resolveOAuthEndpoints', () => {
+	it('resolves the consumers authority for personal accounts', () => {
+		const endpoints = resolveOAuthEndpoints('personal', undefined);
+		expect(endpoints.DEVICE_CODE).toBe('https://login.microsoftonline.com/consumers/oauth2/v2.0/devicecode');
+		expect(endpoints.TOKEN).toBe('https://login.microsoftonline.com/consumers/oauth2/v2.0/token');
+		expect(endpoints.AUTHORIZE).toBe('https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize');
+	});
+
+	it('resolves the organizations authority for work/school accounts', () => {
+		const endpoints = resolveOAuthEndpoints('work-school', undefined);
+		expect(endpoints.DEVICE_CODE).toBe('https://login.microsoftonline.com/organizations/oauth2/v2.0/devicecode');
+	});
+
+	it('resolves a tenant-specific authority when a tenant ID is configured', () => {
+		const endpoints = resolveOAuthEndpoints('tenant', '11111111-1111-1111-1111-111111111111');
+		expect(endpoints.DEVICE_CODE).toBe(
+			'https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/oauth2/v2.0/devicecode'
+		);
+		expect(endpoints.TOKEN).toBe(
+			'https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/oauth2/v2.0/token'
+		);
+	});
+
+	it('throws when the tenant account type has no tenant ID', () => {
+		expect(() => resolveOAuthEndpoints('tenant', undefined)).toThrow(/tenant id/i);
+		expect(() => resolveOAuthEndpoints('tenant', '')).toThrow(/tenant id/i);
+		expect(() => resolveOAuthEndpoints('tenant', '   ')).toThrow(/tenant id/i);
+	});
+
+	it('trims a pasted tenant ID rather than putting whitespace in the authority URL', () => {
+		const endpoints = resolveOAuthEndpoints('tenant', '  contoso.onmicrosoft.com\n');
+		expect(endpoints.DEVICE_CODE).toBe(
+			'https://login.microsoftonline.com/contoso.onmicrosoft.com/oauth2/v2.0/devicecode'
+		);
+	});
+
+	it('rejects a tenant ID that would rewrite the authority path', () => {
+		expect(() => resolveOAuthEndpoints('tenant', 'https://login.microsoftonline.com/abc')).toThrow(
+			/invalid tenant id/i
+		);
+		expect(() => resolveOAuthEndpoints('tenant', 'abc/def')).toThrow(/invalid tenant id/i);
+		expect(() => resolveOAuthEndpoints('tenant', 'a b')).toThrow(/invalid tenant id/i);
+	});
+
+	it('accepts a different identity host for future national-cloud support', () => {
+		const endpoints = resolveOAuthEndpoints('personal', undefined, 'https://login.microsoftonline.us');
+		expect(endpoints.DEVICE_CODE).toBe('https://login.microsoftonline.us/consumers/oauth2/v2.0/devicecode');
+	});
+});
+
+describe('resolveOAuthScopes', () => {
+	it('requests the app folder scope for personal accounts in App Folder mode', () => {
+		expect(resolveOAuthScopes('personal', OneDriveAccessMode.APP_FOLDER)).toEqual(OAUTH_SCOPES_APP_FOLDER);
+	});
+
+	it('requests the full access scope for personal accounts in Full Access mode', () => {
+		expect(resolveOAuthScopes('personal', OneDriveAccessMode.FULL_ACCESS)).toEqual(OAUTH_SCOPES_FULL_ACCESS);
+	});
+
+	it('never requests the app folder scope for work/school or tenant accounts', () => {
+		expect(resolveOAuthScopes('work-school', OneDriveAccessMode.APP_FOLDER)).toEqual(OAUTH_SCOPES_WORK_SCHOOL);
+		expect(resolveOAuthScopes('tenant', OneDriveAccessMode.FULL_ACCESS)).toEqual(OAUTH_SCOPES_WORK_SCHOOL);
+		expect(resolveOAuthScopes('work-school', OneDriveAccessMode.APP_FOLDER)).not.toContain(
+			'Files.ReadWrite.AppFolder'
+		);
+	});
+
+	it('requests a scope that covers shared folders for work/school accounts', () => {
+		// Work/school accounts are forced into Full Access mode, which exposes the
+		// shared-folder browser — that reads other drives.
+		expect(resolveOAuthScopes('work-school', OneDriveAccessMode.FULL_ACCESS)).toContain('Files.ReadWrite.All');
+	});
+
+	it('always includes offline_access so refresh tokens are issued', () => {
+		expect(resolveOAuthScopes('personal', OneDriveAccessMode.APP_FOLDER)).toContain('offline_access');
+		expect(resolveOAuthScopes('work-school', OneDriveAccessMode.FULL_ACCESS)).toContain('offline_access');
+	});
+});

--- a/tests/unit/main.test.ts
+++ b/tests/unit/main.test.ts
@@ -304,6 +304,65 @@ describe('OneDriveSyncPlugin', () => {
 		expect(plugin.settings.appFolderSubpathConfirmed).toBe(true);
 	});
 
+	it('loadSettings resolves a missing accountType to personal without touching stored tokens', async () => {
+		mocks.tokenStorage.hasTokens.mockReturnValue(true);
+		(plugin as any).loadData = vi.fn().mockResolvedValue({
+			connectedUser: { id: '1', displayName: 'Test User', userPrincipalName: 'test@test.com' },
+		});
+
+		await plugin.loadSettings();
+
+		expect(plugin.settings.accountType).toBe('personal');
+		expect(plugin.settings.connectedUser).toBeDefined();
+		expect(mocks.tokenStorage.clearTokens).not.toHaveBeenCalled();
+	});
+
+	it('loadSettings normalizes a bogus accountType to personal', async () => {
+		(plugin as any).loadData = vi.fn().mockResolvedValue({ accountType: null });
+
+		await plugin.loadSettings();
+
+		expect(plugin.settings.accountType).toBe('personal');
+	});
+
+	it('loadSettings forces work/school accounts out of App Folder mode', async () => {
+		(plugin as any).loadData = vi.fn().mockResolvedValue({
+			accountType: 'work-school',
+			accessMode: OneDriveAccessMode.APP_FOLDER,
+		});
+
+		await plugin.loadSettings();
+
+		expect(plugin.settings.accessMode).toBe(OneDriveAccessMode.FULL_ACCESS);
+	});
+
+	it('loadSettings trims identity fields and drops blank ones', async () => {
+		(plugin as any).loadData = vi.fn().mockResolvedValue({
+			accountType: 'tenant',
+			tenantId: '  my-tenant\n',
+			customClientId: '   ',
+		});
+
+		await plugin.loadSettings();
+
+		expect(plugin.settings.tenantId).toBe('my-tenant');
+		expect(plugin.settings.customClientId).toBeUndefined();
+	});
+
+	it('onload fails closed when the tenant authority cannot be resolved', async () => {
+		mocks.tokenStorage.hasTokens.mockReturnValue(true);
+		(plugin as any).loadData = vi.fn().mockResolvedValue({
+			accountType: 'tenant',
+			customClientId: 'a-client-id',
+			tenantId: 'not a valid tenant',
+		});
+
+		await plugin.onload();
+
+		// No auth provider built against a fallback authority
+		expect(mocks.OneDriveAuthProvider).not.toHaveBeenCalled();
+	});
+
 	it('saveSettings persists sync state data (tokens stored in SecretStorage)', async () => {
 		const savedState = { lastSyncTime: 123, fileStates: [['note.md', { path: 'note.md' }]] };
 		mocks.syncStateManager.prepareForSave.mockReturnValue(savedState as any);
@@ -498,6 +557,97 @@ describe('OneDriveSyncPlugin', () => {
 		expect(plugin.settings.remoteRelativePathInShared).toBeUndefined();
 		expect((plugin as any).syncEngine).toBeUndefined();
 		expect((plugin as any).eventManager).toBeUndefined();
+	});
+
+	it('invalidateCredentialsForIdentityChange clears tokens and connection state when identity changes', async () => {
+		mocks.tokenStorage.hasTokens.mockReturnValue(true);
+		(plugin as any).loadData = vi.fn().mockResolvedValue({
+			connectedUser: {
+				id: '1',
+				displayName: 'Test User',
+				userPrincipalName: 'test@test.com',
+			},
+		});
+		await plugin.onload();
+
+		await plugin.invalidateCredentialsForIdentityChange();
+
+		expect(mocks.deviceCodeClient.cancelPolling).toHaveBeenCalled();
+		expect(mocks.tokenStorage.clearTokens).toHaveBeenCalled();
+		expect(mocks.eventManager.stopListening).toHaveBeenCalled();
+		expect(plugin.settings.connectedUser).toBeUndefined();
+		expect((plugin as any).authProvider).toBeUndefined();
+		expect((plugin as any).oneDriveClient).toBeUndefined();
+		expect((plugin as any).syncEngine).toBeUndefined();
+		expect((plugin as any).eventManager).toBeUndefined();
+	});
+
+	it('invalidateCredentialsForIdentityChange clears the previous drive pointers and sync state', async () => {
+		mocks.tokenStorage.hasTokens.mockReturnValue(true);
+		(plugin as any).loadData = vi.fn().mockResolvedValue({
+			remoteDriveId: 'old-drive',
+			remoteItemId: 'old-item',
+			remoteRootName: 'Old Root',
+			remoteRootPath: '/Old Root',
+			remoteRelativePathInShared: 'Vaults/MyVault',
+			connectedUser: { id: '1', displayName: 'Test User', userPrincipalName: 'test@test.com' },
+		});
+		await plugin.onload();
+
+		await plugin.invalidateCredentialsForIdentityChange();
+
+		expect(plugin.settings.remoteDriveId).toBeUndefined();
+		expect(plugin.settings.remoteItemId).toBeUndefined();
+		expect(plugin.settings.remoteRootName).toBeUndefined();
+		expect(plugin.settings.remoteRootPath).toBeUndefined();
+		expect(plugin.settings.remoteRelativePathInShared).toBeUndefined();
+		expect(mocks.syncStateManager.clearState).toHaveBeenCalled();
+	});
+
+	it('invalidateCredentialsForIdentityChange is a no-op when nothing is connected', async () => {
+		await plugin.onload();
+
+		await plugin.invalidateCredentialsForIdentityChange();
+
+		expect(mocks.tokenStorage.clearTokens).not.toHaveBeenCalled();
+	});
+
+	it('authenticate refuses to start for a work/school account with no custom client ID', async () => {
+		(plugin as any).loadData = vi.fn().mockResolvedValue({ accountType: 'work-school' });
+		await plugin.onload();
+
+		await expect(plugin.authenticate()).rejects.toThrow(/custom client id/i);
+		expect(mocks.deviceCodeClient.authenticate).not.toHaveBeenCalled();
+	});
+
+	it('authenticate refuses to start for a tenant account with no tenant ID', async () => {
+		(plugin as any).loadData = vi
+			.fn()
+			.mockResolvedValue({ accountType: 'tenant', customClientId: 'a-client-id' });
+		await plugin.onload();
+
+		await expect(plugin.authenticate()).rejects.toThrow(/tenant id/i);
+		expect(mocks.deviceCodeClient.authenticate).not.toHaveBeenCalled();
+	});
+
+	it('authenticate proceeds for a tenant account once client ID and tenant ID are configured', async () => {
+		(plugin as any).loadData = vi.fn().mockResolvedValue({
+			accountType: 'tenant',
+			customClientId: 'a-client-id',
+			tenantId: 'my-tenant',
+		});
+		await plugin.onload();
+		mocks.deviceCodeClient.authenticate.mockResolvedValue({
+			access_token: 'at',
+			refresh_token: 'rt',
+			expires_in: 3600,
+			token_type: 'Bearer',
+			scope: 'x',
+		});
+
+		await plugin.authenticate();
+
+		expect(mocks.deviceCodeClient.authenticate).toHaveBeenCalled();
 	});
 
 	it('onload prefers the persisted relative path for shared folders', async () => {


### PR DESCRIPTION
## Description

Adds support for work, school, and tenant (Entra ID) accounts, so the plugin can sync with OneDrive for Business. Closes #120.

Sign-in was hardcoded to the `/consumers/` authority, so an Entra ID account could never connect regardless of configuration. An **Account type** setting now selects the authority and the scope set:

| Account type | Authority | Client ID | Access mode |
| ------------ | --------- | --------- | ----------- |
| Personal (default) | `/consumers/` | bundled, custom optional | App Folder or Full Access |
| Work or school (any organization) | `/organizations/` | required | Full Access |
| Work or school (specific organization) | `/{tenantId}/` | required | Full Access |

**Personal accounts are unchanged.** `accountType` is absent in existing saved settings and resolves to `personal`, which reproduces today's authority, scopes, and default access mode. Stored tokens stay valid and no reconnect is triggered. The custom client ID setting also stays exactly where it was for personal accounts — under Advanced, behind the existing opt-in toggle.

Organizational accounts supply their own client ID, because the bundled registration is "Personal Microsoft accounts only" — so nothing changes on your Azure side for this PR.

Notable details:

- **App Folder mode is unavailable to organizational accounts.** Microsoft Graph does not offer `Files.ReadWrite.AppFolder` to work or school accounts, so these accounts are pinned to Full Access and the option is hidden in settings. Requesting it would fail the whole grant.
- **Scope choice.** Organizational accounts request `Files.ReadWrite.All`. The narrower `Files.ReadWrite` is not folder-scoped — it grants the whole of the user's own drive either way — so it buys no containment; it only removes access to other drives, which is what Full Access mode's shared-folder browser needs. Containment to the sync root comes from `buildEndpoint()` path handling.
- **Entra error mapping.** `AADSTS` codes for Conditional Access blocks, unapproved applications, and account-type mismatches are mapped to actionable messages on both the device code request and the token poll, and abort polling rather than retrying a rejection that will not resolve. Codes are matched whole, so a longer code sharing a prefix (`AADSTS530032` vs `AADSTS53003`) is not misdiagnosed.
- **Identity changes discard credentials.** Changing account type, tenant ID, or client ID clears stored tokens plus the previous drive pointers and sync state, since refresh tokens are bound to the issuing authority and client, and drive/item IDs are scoped to the previous drive. This fires when a field is committed (blur or Enter), not per keystroke.
- **Unresolvable authority fails closed** rather than falling back to the consumer endpoint with an organizational identity.
- Both settings UI paths are updated — the declarative `getSettingDefinitions()` and the legacy `display()` path.
- Conditional Access, Continuous Access Evaluation, and vault-placement caveats are documented in `docs/ADVANCED.md`, along with an app-registration walkthrough.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

- [x] Tests pass (`npm test`) — 527 tests across 20 files, including new coverage for endpoint resolution, scope selection, the device code flow's new constructor, Entra error mapping, and credential invalidation
- [x] Build succeeds (`npm run build`)
- [x] Manually tested in Obsidian

### Live validation against a real Microsoft 365 Business tenant

You mentioned in #120 that you did not have a subscription to test against. This change was validated end to end on a live tenant using account type "specific organization", against a folder on OneDrive for Business:

- Device code grant completes against `https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/devicecode`
- First full sync: uploads, downloads, deletes in both directions, renames (no duplicates), and a chunked upload above the 4 MB threshold
- Folder-scoped delta works against a SharePoint-backed drive: the delta is scoped to the sync root rather than the whole drive, `@odata.deltaLink` is returned and reused, and subsequent syncs return only changed items. A sync root containing a space and brackets round-tripped correctly
- Token refresh: three consecutive unattended refreshes across several hours, each followed by a successful sync and no reconnect prompt

## Checklist

- [x] Code follows existing style
- [x] Self-reviewed the changes
- [x] Updated documentation if needed
