### PR TITLE
fix(auth): prevent NaN expiry comparisons from marking broken tokens as never-expiring

### DIFF
--- a/src/auth/tokenStorage.ts
+++ b/src/auth/tokenStorage.ts
@@ -57,11 +57,18 @@ export class TokenStorage {
 		const expiresInStr = this.app.secretStorage.getSecret(SECRET_KEYS.EXPIRES_IN);
 
 		if (accessToken && refreshToken && expiresAtStr) {
+			const expiresAt = Number(expiresAtStr);
+			const expiresIn = Number(expiresInStr);
 			this.tokens = {
 				accessToken,
 				refreshToken,
-				expiresAt: Number(expiresAtStr),
-				expiresIn: expiresInStr ? Number(expiresInStr) : 3600,
+				// Guard against NaN (comparisons always false). For expiry: 0 = immediately expired,
+				// and only positive expiresIn values are accepted; otherwise safe defaults apply.
+				expiresAt: Number.isFinite(expiresAt) ? expiresAt : 0,
+				expiresIn:
+					(expiresInStr && Number.isFinite(expiresIn) && expiresIn > 0)
+						? expiresIn
+						: 3600,
 			};
 			logger.debug('Tokens loaded from SecretStorage');
 			return false; // No migration needed

--- a/tests/unit/auth/tokenStorage.test.ts
+++ b/tests/unit/auth/tokenStorage.test.ts
@@ -75,6 +75,20 @@ describe('TokenStorage', () => {
 			expect(newStorage.getRefreshToken()).toBe('stored-refresh');
 		});
 
+		it('should sanitize a corrupt (non-numeric) expiry into an expired token', async () => {
+			mockApp.secretStorage.setSecret('access-token', 'access');
+			mockApp.secretStorage.setSecret('refresh-token', 'refresh');
+			mockApp.secretStorage.setSecret('token-expires-at', 'not-a-number');
+
+			await storage.loadTokens();
+
+			// NaN comparisons always return false, which would make a broken
+			// token appear never-expiring; the loader must coerce it to 0
+			// (already expired) so the refresh path runs.
+			expect(storage.hasTokens()).toBe(true);
+			expect(storage.isAccessTokenExpired()).toBe(true);
+		});
+
 		it('should migrate legacy obfuscated tokens from data.json', async () => {
 			// Create obfuscated tokens in legacy format
 			const accessToken = 'test_access_token_12345';


### PR DESCRIPTION
## Description

Fixes a bug in token expiry handling that could cause corrupted tokens to be treated as never-expiring.

Previously, when loading tokens from `SecretStorage`, the `expiresAt` and `expiresIn` values were converted with `Number(...)` without validating the result. If the stored value was non-numeric (e.g. corrupted or malformed), `Number()` returned `NaN`. Since `NaN` comparisons always evaluate to false, the expiry check (`isAccessTokenExpired`) would never trigger, causing a broken token to appear valid forever and preventing the refresh flow from ever running.

The fix sanitizes these values on load:
* `expiresAt` is coerced to `0` (immediately expired) when it is not a finite number, forcing the refresh path to run.
* `expiresIn` falls back to the safe default of `3600` seconds unless it is a finite, positive number.

A unit test was added to cover the corrupt/non-numeric expiry scenario, verifying that such a token is correctly detected as expired.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Manually tested in Obsidian

## Checklist

- [x] Code follows existing style
- [x] Self-reviewed the changes
- [ ] Updated documentation if needed
