### PR TITLE
perf: defer authenticated init off the load path to speed up Obsidian startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Sync your Obsidian vault with **OneDrive**. Zero-config for personal Microsoft a
 | Setting                  | Description                                                                                                                                                               |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Sync Interval**        | Set to 0 for manual-only sync (recommended for battery)                                                                                                                   |
-| **Startup Sync Delay**   | Delay before first sync after launch (0 = disabled, 10s recommended)                                                                                                      |
+| **Startup Sync Delay**   | Delay before the first sync after the plugin finishes initializing (0 = disabled, 10s recommended)                                                                                                      |
 | **Conflict Resolution**  | Last write wins (default), create duplicate, or manual                                                                                                                    |
 | **Sync App Settings**    | Optional — sync `.obsidian/app.json`, `.obsidian/appearance.json`, and `.obsidian/hotkeys.json` to keep appearance and hotkeys consistent across devices                  |
 | **Sync Plugins**         | Optional — sync plugin lists, manifests, and binaries (`main.js`, `styles.css`). Does **not** sync plugin data files (`data.json`)                                        |

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -76,6 +76,7 @@ export const de = {
 			notConnected: 'Nicht mit OneDrive verbunden. Bitte in Einstellungen verbinden.',
 			selectFolderFirst: 'Bitte wählen Sie zuerst einen Synchronisierungsordner in den Einstellungen.',
 			engineNotInitialized: 'Synchronisierungs-Engine nicht initialisiert. Bitte neu verbinden.',
+			initializing: 'Die Synchronisierung wird noch initialisiert. Bitte versuchen Sie es gleich erneut.',
 			alreadyInProgress: 'Synchronisierung läuft bereits',
 			failed: 'Synchronisierung fehlgeschlagen: {{message}}',
 			folderSet: 'Synchronisierungsordner gesetzt auf: {{path}}',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -77,6 +77,7 @@ export const en = {
 			notConnected: 'Not connected to OneDrive. Please connect in settings.',
 			selectFolderFirst: 'Please select a sync folder in settings first.',
 			engineNotInitialized: 'Sync engine not initialized. Please reconnect.',
+			initializing: 'Sync is still initializing. Please try again in a moment.',
 			alreadyInProgress: 'Sync already in progress',
 			failed: 'Sync failed: {{message}}',
 			folderSet: 'Sync folder set to: {{path}}',

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -76,6 +76,7 @@ export const es = {
 			notConnected: 'No conectado a OneDrive. Por favor conecta en ajustes.',
 			selectFolderFirst: 'Por favor selecciona una carpeta de sincronización en ajustes primero.',
 			engineNotInitialized: 'Motor de sincronización no inicializado. Por favor reconecta.',
+			initializing: 'La sincronización aún se está inicializando. Inténtalo de nuevo en un momento.',
 			alreadyInProgress: 'Sincronización ya en progreso',
 			failed: 'Sincronización fallida: {{message}}',
 			folderSet: 'Carpeta de sincronización establecida en: {{path}}',

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -76,6 +76,7 @@ export const fr = {
 			notConnected: 'Non connecté à OneDrive. Veuillez vous connecter dans les paramètres.',
 			selectFolderFirst: 'Veuillez d\'abord sélectionner un dossier de synchronisation dans les paramètres.',
 			engineNotInitialized: 'Moteur de synchronisation non initialisé. Veuillez vous reconnecter.',
+			initializing: 'La synchronisation est encore en cours d\'initialisation. Réessayez dans un instant.',
 			alreadyInProgress: 'Synchronisation déjà en cours',
 			failed: 'Synchronisation échouée: {{message}}',
 			folderSet: 'Dossier de synchronisation défini sur: {{path}}',

--- a/src/i18n/locales/it.ts
+++ b/src/i18n/locales/it.ts
@@ -76,6 +76,7 @@ export const it = {
 			notConnected: 'Non connesso a OneDrive. Connetti nelle impostazioni.',
 			selectFolderFirst: 'Seleziona prima una cartella di sincronizzazione nelle impostazioni.',
 			engineNotInitialized: 'Motore di sincronizzazione non inizializzato. Riconnetti.',
+			initializing: 'La sincronizzazione è ancora in fase di inizializzazione. Riprova tra poco.',
 			alreadyInProgress: 'Sincronizzazione già in corso',
 			failed: 'Sincronizzazione fallita: {{message}}',
 			folderSet: 'Cartella di sincronizzazione impostata su: {{path}}',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -75,6 +75,7 @@ export const ja = {
 			notConnected: 'OneDriveに接続されていません。設定で接続してください。',
 			selectFolderFirst: '設定で同期フォルダを先に選択してください。',
 			engineNotInitialized: '同期エンジンが初期化されていません。再接続してください。',
+			initializing: '同期はまだ初期化中です。しばらくしてから再度お試しください。',
 			alreadyInProgress: '同期は既に進行中です',
 			failed: '同期に失敗しました: {{message}}',
 			folderSet: '同期フォルダを設定しました: {{path}}',

--- a/src/i18n/locales/pt.ts
+++ b/src/i18n/locales/pt.ts
@@ -76,6 +76,7 @@ export const pt = {
 			notConnected: 'Não conectado ao OneDrive. Por favor, conecte nas configurações.',
 			selectFolderFirst: 'Por favor, selecione uma pasta de sincronização nas configurações primeiro.',
 			engineNotInitialized: 'Motor de sincronização não inicializado. Por favor, reconecte.',
+			initializing: 'A sincronização ainda está inicializando. Tente novamente em instantes.',
 			alreadyInProgress: 'Sincronização já em andamento',
 			failed: 'Sincronização falhou: {{message}}',
 			folderSet: 'Pasta de sincronização definida como: {{path}}',

--- a/src/i18n/locales/zh-cn.ts
+++ b/src/i18n/locales/zh-cn.ts
@@ -74,6 +74,7 @@ export const zhCn = {
 			notConnected: '尚未连接 OneDrive。请先在设置中连接。',
 			selectFolderFirst: '请先在设置中选择同步文件夹。',
 			engineNotInitialized: '同步引擎尚未初始化，请重新连接。',
+			initializing: '同步功能初始化中，请稍后再试。',
 			alreadyInProgress: '同步正在进行',
 			failed: '同步失败：{{message}}',
 			folderSet: '同步文件夹已设为：{{path}}',

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,6 +105,11 @@ export default class OneDriveSyncPlugin extends Plugin {
 	// Sync state
 	private isSyncing = false;
 
+	// True while authenticated components are being initialized off the load
+	// path (network calls, sync-engine construction). Used to give a friendlier
+	// message when a manual sync is requested before initialization completes.
+	private isInitializing = false;
+
 	// UI components
 	private statusBarManager?: StatusBarManager;
 	private currentSyncStatus: SyncStatus = SyncStatus.DISCONNECTED;
@@ -157,9 +162,12 @@ export default class OneDriveSyncPlugin extends Plugin {
 			);
 		}
 
-		// Initialize authenticated components if we have tokens
+		// Kick off authenticated initialization (API clients, event listeners,
+		// periodic/startup sync). This involves network calls (e.g. app-folder
+		// resolution) that should NOT block Obsidian's startup, so it
+		// runs asynchronously after onload returns.
 		if (this.tokenStorage.hasTokens()) {
-			await this.initializeAuthenticatedComponents();
+			void this.initializeAfterLoad();
 		}
 
 		// Add ribbon icon for manual sync
@@ -256,26 +264,41 @@ export default class OneDriveSyncPlugin extends Plugin {
 		// Add settings tab
 		this.addSettingTab(new OneDriveSettingTab(this.app, this));
 
-		// Start event listeners and periodic sync only if sync target is configured
-		if (this.tokenStorage.hasTokens() && this.eventManager && this.isSyncConfigured()) {
-			this.eventManager.startListening();
-			this.eventManager.startPeriodicSync(this.settings.syncInterval || 0);
-		}
-
-		// Perform startup sync if configured and sync target is set
-		if (
-			this.tokenStorage.hasTokens() &&
-			this.settings.startupSyncDelay > 0 &&
-			this.isSyncConfigured()
-		) {
-			logger.info(`Startup sync scheduled: will run in ${this.settings.startupSyncDelay}s`);
-			timerApi.setTimeout(() => {
-				logger.info('Startup sync delay elapsed — triggering sync');
-				void this.triggerManualSync();
-			}, this.settings.startupSyncDelay * 1000);
-		}
-
 		logger.info('OneDrive Sync plugin loaded successfully');
+	}
+
+	/**
+	 * Finish authenticated initialization off the load path.
+	 *
+	 * `onload()` awaits only local work so Obsidian can finish starting up;
+	 * everything that needs the network (app-folder resolution, user info) or
+	 * depends on it (event listeners, periodic/startup sync) runs here, async,
+	 * after the plugin is already usable.
+	 */
+	private async initializeAfterLoad(): Promise<void> {
+		this.isInitializing = true;
+		try {
+			await this.initializeAuthenticatedComponents();
+
+			// The above set up `eventManager`; now start listening + periodic sync,
+			// and schedule the deferred startup sync.
+			if (this.eventManager && this.isSyncConfigured()) {
+				this.eventManager.startListening();
+				this.eventManager.startPeriodicSync(this.settings.syncInterval || 0);
+			}
+
+			if (this.settings.startupSyncDelay > 0 && this.isSyncConfigured()) {
+				logger.info(`Startup sync scheduled: will run in ${this.settings.startupSyncDelay}s`);
+				timerApi.setTimeout(() => {
+					logger.info('Startup sync delay elapsed — triggering sync');
+					void this.triggerManualSync();
+				}, this.settings.startupSyncDelay * 1000);
+			}
+
+			logger.info('Authenticated initialization completed; event listeners and startup sync scheduled');
+		} finally {
+			this.isInitializing = false;
+		}
 	}
 
 	onunload() {
@@ -440,18 +463,43 @@ export default class OneDriveSyncPlugin extends Plugin {
 				}
 			);
 
-			// Get user info to display in settings
+			// Get user info to display in settings. This is display-only and must
+			// not block initialization (and thus event listeners / startup sync),
+			// so fetch it in the background and persist when it arrives.
 			if (!this.settings.connectedUser) {
-				const userInfo = await this.oneDriveClient.getUserInfo();
-				this.settings.connectedUser = userInfo;
-				await this.saveSettings();
+				void this.loadConnectedUser();
 			}
 
 			logger.info('Authenticated components initialized');
 		} catch (error) {
 			logger.error('Failed to initialize authenticated components:', error);
 			new Notice(t('notices.auth.clientInitFailed'));
+			return;
 		}
+	}
+
+	/**
+	 * Fetch and cache the connected user's display info for the settings UI.
+	 * Fire-and-forget: never blocks initialization or sync.
+	 * @returns true if the cached user info was updated.
+	 */
+	async loadConnectedUser(): Promise<boolean> {
+		if (!this.oneDriveClient || this.settings.connectedUser) {
+			return false;
+		}
+
+		try {
+			const userInfo = await this.oneDriveClient.getUserInfo();
+			// Re-check: a disconnect/reconnect may have happened meanwhile.
+			if (!this.settings.connectedUser) {
+				this.settings.connectedUser = userInfo;
+				await this.saveSettings();
+				return true;
+			}
+		} catch (error) {
+			logger.warn('Failed to load connected user info:', error);
+		}
+		return false;
 	}
 
 	private buildDeviceCodeClient(): DeviceCodeFlowClient {
@@ -687,7 +735,7 @@ export default class OneDriveSyncPlugin extends Plugin {
 		}
 
 		if (!this.syncEngine) {
-			new Notice(t('notices.sync.engineNotInitialized'));
+			new Notice(t(this.isInitializing ? 'notices.sync.initializing' : 'notices.sync.engineNotInitialized'));
 			return;
 		}
 
@@ -1267,7 +1315,7 @@ export default class OneDriveSyncPlugin extends Plugin {
 			return;
 		}
 		if (!this.syncEngine) {
-			new Notice(t('notices.reconcile.engineNotInitialized'));
+			new Notice(t(this.isInitializing ? 'notices.sync.initializing' : 'notices.reconcile.engineNotInitialized'));
 			return;
 		}
 		if (this.isSyncing || this.eventManager?.isSyncInProgress()) {
@@ -1304,7 +1352,7 @@ export default class OneDriveSyncPlugin extends Plugin {
 			return;
 		}
 		if (!this.syncEngine) {
-			new Notice(t('notices.reconcileToCloud.engineNotInitialized'));
+			new Notice(t(this.isInitializing ? 'notices.sync.initializing' : 'notices.reconcileToCloud.engineNotInitialized'));
 			return;
 		}
 		if (this.isSyncing || this.eventManager?.isSyncInProgress()) {

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -73,6 +73,7 @@ interface OneDrivePlugin extends Plugin {
 	getExperimentalSetting<K extends keyof ExperimentalSettings>(key: K): ExperimentalSettings[K];
 	invalidateCredentialsForIdentityChange(): Promise<void>;
 	normalizeIdentitySettings(): void;
+	loadConnectedUser(): Promise<boolean>;
 }
 
 /**
@@ -498,6 +499,16 @@ export class OneDriveSettingTab extends PluginSettingTab {
 	// display() is the imperative rendering entry point, called by Obsidian
 	// when the settings tab is opened on versions before 1.13.
 	display(): void {
+		// If the display name hasn't been loaded yet (it's fetched in the
+		// background after startup via loadConnectedUser()), kick it off and
+		// re-render once it arrives so the user sees their account.
+		if (this.plugin.settings.connectedUser === undefined) {
+			void this.plugin.loadConnectedUser().then((updated: boolean) => {
+				if (updated) {
+					this.renderSettings();
+				}
+			});
+		}
 		this.renderSettings();
 	}
 


### PR DESCRIPTION
## Description

Defer authenticated initialization (API clients, event listeners, periodic/startup sync) off the plugin’s `onload()` path and run it asynchronously in the background. This prevents network calls from blocking Obsidian’s startup.

**Before / After plugin load time:**

| Platform | Before  | After  |
| -------- | ------- | ------ |
| Windows  | ~1610ms | ~15ms  |
| Android  | ~2016ms | ~131ms |

Additional changes:
- Startup sync delay now starts after initialization completes (matches updated README).
- Manual sync during initialization shows a friendly “still initializing” notice instead of “engine not initialized”.
- Added `initializing` string to all locale files.
- Settings UI loads connected user info in the background and re-renders when ready.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] Tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)
- [x] Manually tested in Obsidian

## Checklist

- [x] Code follows existing style
- [x] Self-reviewed the changes
- [x] Updated documentation if needed