### PR TITLE
Fix duplicate files when a rename is received from another device (#50)

### DIFF
--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -125,6 +125,18 @@ interface RemoteFolderMove {
 }
 
 /**
+ * A file that was moved/renamed on the remote. Detected by the delta
+ * reporting a OneDrive item id we already track under a different vault
+ * path — the signature of an atomic PATCH move performed by another device
+ * (the id survives the move, so no delete/create pair is emitted).
+ */
+interface RemoteFileMove {
+	oldPath: string;
+	newPath: string;
+	item: OneDriveItem;
+}
+
+/**
  * Returned by expandFolderDeletes: synthetic per-file delete items derived
  * from Graph folder-delete entries, plus the folder paths that were deleted,
  * plus any folder moves/renames detected on the remote.
@@ -294,6 +306,17 @@ export class SyncEngine {
 			// new downloads or left stranded in stale folders (issue #163).
 			if (folderMoves.length > 0) {
 				await this.applyRemoteFolderMoves(folderMoves);
+			}
+
+			// Apply any file moves/renames detected on the remote (a file
+			// renamed on another device via an atomic PATCH move keeps its
+			// OneDrive id, so the delta reports it only at its new path —
+			// with no delete for the old one). Runs after folder moves so
+			// descendants relocated above are already tracked at their new
+			// paths and aren't mistaken for individual file moves (issue #50).
+			const fileMoves = this.detectRemoteFileMoves(remoteChanges, localChanges);
+			if (fileMoves.length > 0) {
+				await this.applyRemoteFileMoves(fileMoves);
 			}
 
 			// Phase 3: Diff local vs remote to produce upload/download/conflict ops
@@ -1954,6 +1977,155 @@ export class SyncEngine {
 					`Failed to apply remote folder move ${oldPath} → ${newPath}: ${error instanceof Error ? error.message : error}`
 				);
 			}
+		}
+	}
+
+	/**
+	 * Detect files that were renamed/moved on the remote.
+	 *
+	 * When another device performs an atomic move (OneDrive PATCH), the item
+	 * keeps its id and Graph delta reports it once, at its NEW path — there
+	 * is no delete entry for the old path. Without this pass the planner sees
+	 * only "a file we don't track at this path" and downloads it, leaving the
+	 * old local copy behind forever: the duplicate reported in issue #50.
+	 *
+	 * A tracked id resolving to a different vault path than the one the delta
+	 * reports is the fingerprint of that move.
+	 */
+	private detectRemoteFileMoves(
+		remoteChanges: OneDriveItem[],
+		localChanges: LocalChange[]
+	): RemoteFileMove[] {
+		// Paths the local pass owns this cycle. Relocating underneath it would
+		// race with an upload/conflict decision, so leave those alone.
+		const locallyTouched = new Set<string>();
+		for (const change of localChanges) {
+			locallyTouched.add(change.path);
+			if (change.oldPath) locallyTouched.add(change.oldPath);
+		}
+
+		const moves: RemoteFileMove[] = [];
+		for (const item of remoteChanges) {
+			if (item.deleted || !item.file || !item.id) continue;
+			const newPath = this.remotePathToVaultPath(item);
+			if (!newPath) continue;
+			const oldPath = this.stateManager.getPathByOneDriveId(item.id);
+			if (!oldPath || oldPath === newPath) continue;
+			if (locallyTouched.has(oldPath) || locallyTouched.has(newPath)) {
+				logger.debug(
+					`Remote file move ${oldPath} → ${newPath}: skipped, path has a pending local change`
+				);
+				continue;
+			}
+			if (this.conflictQueue?.hasConflict(oldPath) || this.conflictQueue?.hasConflict(newPath)) {
+				logger.debug(`Remote file move ${oldPath} → ${newPath}: skipped, pending conflict`);
+				continue;
+			}
+			logger.info(`Remote file move detected: ${oldPath} → ${newPath} (id=${item.id})`);
+			moves.push({ oldPath, newPath, item });
+		}
+		return moves;
+	}
+
+	/**
+	 * Apply remote file moves to the local vault so the old path doesn't
+	 * survive as a duplicate alongside the newly downloaded copy.
+	 *
+	 * Renaming in place (rather than deleting + re-downloading) keeps the
+	 * local content and lets the remote pass skip the download entirely when
+	 * the move was a pure rename — the tracked hash moves with the state and
+	 * still matches the delta item.
+	 */
+	private async applyRemoteFileMoves(fileMoves: RemoteFileMove[]): Promise<void> {
+		const adapter = this.app.vault.adapter;
+
+		for (const { oldPath, newPath } of fileMoves) {
+			const trackedState = this.stateManager.getFileState(oldPath);
+			const oldFile = this.app.vault.getAbstractFileByPath(oldPath);
+			const oldExists = oldFile instanceof TFile || (await adapter.exists(oldPath));
+
+			if (!oldExists) {
+				// Nothing local to relocate (never downloaded here, or already
+				// removed). Drop the stale tracking so the remote pass treats
+				// the new path as a fresh download instead of a no-op.
+				logger.debug(`Remote file move ${oldPath} → ${newPath}: no local file to move`);
+				this.stateManager.removeFileState(oldPath);
+				continue;
+			}
+
+			// If the new path is already populated locally, the old path is a
+			// stale duplicate of the same remote item — trash it rather than
+			// renaming onto an existing file (which would throw).
+			const destOccupied =
+				this.app.vault.getAbstractFileByPath(newPath) !== null || (await adapter.exists(newPath));
+			if (destOccupied) {
+				logger.info(
+					`Remote file move ${oldPath} → ${newPath}: destination already exists locally, ` +
+						`removing the stale copy at the old path`
+				);
+				try {
+					await this.deleteLocalFile(oldPath);
+				} catch (error) {
+					logger.warn(
+						`Failed to remove stale local copy ${oldPath}: ${error instanceof Error ? error.message : error}`
+					);
+					this.stateManager.removeFileState(oldPath);
+				}
+				continue;
+			}
+
+			const isVaultFile = oldFile instanceof TFile;
+			this.eventManager.markOwnWrites([oldPath, newPath]);
+			try {
+				await this.ensureVaultFolders(newPath);
+				if (isVaultFile) {
+					await this.app.vault.rename(oldFile, newPath);
+					// The rename event fires against the new path and consumes
+					// that marker; the old-path one has nothing left to
+					// suppress, so drop it rather than letting it swallow a
+					// future event for a file the user recreates there.
+					this.eventManager.removeOwnWrite(oldPath);
+				} else {
+					// Config files aren't in the vault index — move via adapter.
+					// No vault events fire for these, so neither marker would
+					// ever be consumed; the tracked state we write below is
+					// what keeps the mtime scan from seeing a phantom change.
+					await adapter.rename(oldPath, newPath);
+					this.eventManager.removeOwnWrite(oldPath);
+					this.eventManager.removeOwnWrite(newPath);
+				}
+			} catch (error) {
+				this.eventManager.removeOwnWrite(oldPath);
+				this.eventManager.removeOwnWrite(newPath);
+				logger.warn(
+					`Failed to apply remote file move ${oldPath} → ${newPath}: ${error instanceof Error ? error.message : error}`
+				);
+				continue;
+			}
+
+			// Carry the tracked state across so the remote pass can compare
+			// hashes at the new path (pure rename → no re-download).
+			this.stateManager.removeFileState(oldPath);
+			if (trackedState) {
+				let localMtime = trackedState.localMtime;
+				const movedFile = this.app.vault.getAbstractFileByPath(newPath);
+				if (movedFile instanceof TFile) {
+					localMtime = movedFile.stat.mtime;
+				} else {
+					try {
+						const stat = await adapter.stat(newPath);
+						if (stat?.mtime) localMtime = stat.mtime;
+					} catch {
+						// keep the previous mtime — a mismatch only costs a re-hash
+					}
+				}
+				this.stateManager.setFileState(newPath, {
+					...trackedState,
+					path: newPath,
+					localMtime,
+				});
+			}
+			logger.info(`Applied remote file move locally: ${oldPath} → ${newPath}`);
 		}
 	}
 

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -1194,7 +1194,12 @@ export class SyncEngine {
 						moveFromId: oldState.oneDriveId,
 						remoteState: oldState,
 					});
-					this.stateManager.removeFileState(change.oldPath);
+					// The old path's state is retired by the MOVE branch of
+					// executeOperation, once the move actually succeeds.
+					// Dropping it here would untrack the file whenever the
+					// move failed, and the retry would then take the "no
+					// tracked state for old path" branch and strand a copy on
+					// OneDrive under the old name.
 					remoteByPath.delete(change.path);
 					continue;
 				}
@@ -1460,6 +1465,13 @@ export class SyncEngine {
 				const remotePath = this.vaultPathToRemotePath(operation.path);
 				logger.info(`Moving item to ${remotePath}`);
 				const movedItem = await this.fileOps.moveFile(operation.moveFromId, remotePath);
+
+				// The move landed — only now is it safe to retire the old
+				// path's tracked state.
+				const movedFromPath = operation.remoteState?.path;
+				if (movedFromPath && movedFromPath !== operation.path) {
+					this.stateManager.removeFileState(movedFromPath);
+				}
 
 				// Update state with new path and item metadata
 				const localFile = this.app.vault.getAbstractFileByPath(operation.path);

--- a/src/sync/syncEngine.ts
+++ b/src/sync/syncEngine.ts
@@ -315,12 +315,25 @@ export class SyncEngine {
 			// descendants relocated above are already tracked at their new
 			// paths and aren't mistaken for individual file moves (issue #50).
 			const fileMoves = this.detectRemoteFileMoves(remoteChanges, localChanges);
+			let plannableRemoteChanges = remoteChanges;
 			if (fileMoves.length > 0) {
-				await this.applyRemoteFileMoves(fileMoves);
+				const consumedDeleteIds = await this.applyRemoteFileMoves(fileMoves, remoteChanges);
+				if (consumedDeleteIds.size > 0) {
+					// These deletes were already applied to clear a move
+					// destination; leaving them in would delete the file we
+					// just moved into that path.
+					plannableRemoteChanges = remoteChanges.filter(
+						(item) => !(item.deleted && item.id && consumedDeleteIds.has(item.id))
+					);
+				}
 			}
 
 			// Phase 3: Diff local vs remote to produce upload/download/conflict ops
-			const operations = await this.planOperations(localChanges, remoteChanges, isFirstSync);
+			const operations = await this.planOperations(
+				localChanges,
+				plannableRemoteChanges,
+				isFirstSync
+			);
 
 			// On first sync the dirty queue is empty, so walk the vault and add
 			// uploads for any local-only files not already covered by the delta
@@ -2011,6 +2024,31 @@ export class SyncEngine {
 			if (!newPath) continue;
 			const oldPath = this.stateManager.getPathByOneDriveId(item.id);
 			if (!oldPath || oldPath === newPath) continue;
+			// The id is already tracked at the path the delta reports, so the
+			// item has not moved — the other path is a stale alias sharing the
+			// id (CREATE_DUPLICATE conflict copies are downloaded with the base
+			// file's id). Treating that as a move would trash the copy.
+			if (this.stateManager.getFileState(newPath)?.oneDriveId === item.id) {
+				logger.debug(
+					`Remote file move ${oldPath} → ${newPath}: skipped, ${newPath} already tracks this id`
+				);
+				continue;
+			}
+			// Guard against a delta batch captured before a move we already
+			// applied: an item reported strictly older than the state we hold
+			// would rename the file backwards.
+			const trackedState = this.stateManager.getFileState(oldPath);
+			const itemModified = new Date(item.lastModifiedDateTime).getTime();
+			if (
+				trackedState &&
+				Number.isFinite(itemModified) &&
+				itemModified < trackedState.remoteModifiedTime
+			) {
+				logger.debug(
+					`Remote file move ${oldPath} → ${newPath}: skipped, delta item is older than tracked state`
+				);
+				continue;
+			}
 			if (locallyTouched.has(oldPath) || locallyTouched.has(newPath)) {
 				logger.debug(
 					`Remote file move ${oldPath} → ${newPath}: skipped, path has a pending local change`
@@ -2036,10 +2074,26 @@ export class SyncEngine {
 	 * the move was a pure rename — the tracked hash moves with the state and
 	 * still matches the delta item.
 	 */
-	private async applyRemoteFileMoves(fileMoves: RemoteFileMove[]): Promise<void> {
+	private async applyRemoteFileMoves(
+		fileMoves: RemoteFileMove[],
+		remoteChanges: OneDriveItem[]
+	): Promise<Set<string>> {
 		const adapter = this.app.vault.adapter;
 
-		for (const { oldPath, newPath } of fileMoves) {
+		// Ids this batch deletes. Obsidian refuses to rename onto an existing
+		// name, so "delete B, then rename A → B" is a common shape; when the
+		// file sitting at our destination is one this same batch removes, we
+		// must delete it first and then move in — not mistake it for a
+		// pre-existing duplicate and trash the source instead.
+		const deletedIdsInBatch = new Set<string>();
+		for (const item of remoteChanges) {
+			if (item.deleted && item.id) deletedIdsInBatch.add(item.id);
+		}
+		// Delete entries we handle here, so the planner doesn't delete the
+		// file again after we've moved the survivor into its place.
+		const consumedDeleteIds = new Set<string>();
+
+		for (const { oldPath, newPath, item } of fileMoves) {
 			const trackedState = this.stateManager.getFileState(oldPath);
 			const oldFile = this.app.vault.getAbstractFileByPath(oldPath);
 			const oldExists = oldFile instanceof TFile || (await adapter.exists(oldPath));
@@ -2053,12 +2107,38 @@ export class SyncEngine {
 				continue;
 			}
 
-			// If the new path is already populated locally, the old path is a
-			// stale duplicate of the same remote item — trash it rather than
-			// renaming onto an existing file (which would throw).
+			// A case-only rename ("Test.md" → "test.md") is a real move, but
+			// adapter.exists is case-insensitive by default and would report
+			// the destination as occupied. Obsidian handles these renames, so
+			// skip the occupancy check entirely.
+			const caseOnlyRename = oldPath.toLowerCase() === newPath.toLowerCase();
+			// `sensitive: true` so a differently-cased sibling isn't mistaken
+			// for the destination.
 			const destOccupied =
-				this.app.vault.getAbstractFileByPath(newPath) !== null || (await adapter.exists(newPath));
-			if (destOccupied) {
+				!caseOnlyRename &&
+				(this.app.vault.getAbstractFileByPath(newPath) !== null ||
+					(await adapter.exists(newPath, true)));
+
+			// The occupant is scheduled for deletion in this very batch —
+			// remove it now so the move can land, and drop the delete entry so
+			// the planner doesn't then delete what we moved in.
+			const occupantState = destOccupied ? this.stateManager.getFileState(newPath) : undefined;
+			const occupantId = occupantState?.oneDriveId;
+			if (destOccupied && occupantId && deletedIdsInBatch.has(occupantId)) {
+				logger.info(
+					`Remote file move ${oldPath} → ${newPath}: destination is deleted in this batch, ` +
+						`removing it first so the move can land`
+				);
+				try {
+					await this.deleteLocalFile(newPath);
+					consumedDeleteIds.add(occupantId);
+				} catch (error) {
+					logger.warn(
+						`Failed to clear move destination ${newPath}: ${error instanceof Error ? error.message : error}`
+					);
+					continue;
+				}
+			} else if (destOccupied) {
 				logger.info(
 					`Remote file move ${oldPath} → ${newPath}: destination already exists locally, ` +
 						`removing the stale copy at the old path`
@@ -2095,12 +2175,29 @@ export class SyncEngine {
 					this.eventManager.removeOwnWrite(newPath);
 				}
 			} catch (error) {
+				// vault.rename can fail when the destination folder was just
+				// created through the adapter and isn't in the vault index yet.
+				// Fall back to an adapter-level move before giving up, so we
+				// don't silently regress to leaving a duplicate behind.
+				let recovered = false;
+				if (isVaultFile) {
+					try {
+						await adapter.rename(oldPath, newPath);
+						recovered = true;
+						logger.info(`Remote file move ${oldPath} → ${newPath}: used adapter fallback`);
+					} catch {
+						// fall through to the warning below
+					}
+				}
+				if (!recovered) {
+					this.eventManager.removeOwnWrite(oldPath);
+					this.eventManager.removeOwnWrite(newPath);
+					logger.warn(
+						`Failed to apply remote file move ${oldPath} → ${newPath}: ${error instanceof Error ? error.message : error}`
+					);
+					continue;
+				}
 				this.eventManager.removeOwnWrite(oldPath);
-				this.eventManager.removeOwnWrite(newPath);
-				logger.warn(
-					`Failed to apply remote file move ${oldPath} → ${newPath}: ${error instanceof Error ? error.message : error}`
-				);
-				continue;
 			}
 
 			// Carry the tracked state across so the remote pass can compare
@@ -2119,14 +2216,23 @@ export class SyncEngine {
 						// keep the previous mtime — a mismatch only costs a re-hash
 					}
 				}
+				const itemModified = new Date(item.lastModifiedDateTime).getTime();
 				this.stateManager.setFileState(newPath, {
 					...trackedState,
 					path: newPath,
 					localMtime,
+					// Refresh the remote timestamp, but NOT the hash — the hash
+					// is what tells the planner whether this move also carried
+					// a content change that still needs downloading.
+					remoteModifiedTime: Number.isFinite(itemModified)
+						? itemModified
+						: trackedState.remoteModifiedTime,
 				});
 			}
 			logger.info(`Applied remote file move locally: ${oldPath} → ${newPath}`);
 		}
+
+		return consumedDeleteIds;
 	}
 
 	/**

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -21,6 +21,7 @@ export const mockApp = {
 			readBinary: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
 			mkdir: vi.fn().mockResolvedValue(undefined),
 			rmdir: vi.fn().mockResolvedValue(undefined),
+			rename: vi.fn().mockResolvedValue(undefined),
 			getBasePath: vi.fn().mockReturnValue('/mock/vault'),
 		},
 		on: vi.fn().mockReturnValue({ id: 'mock-event-ref' }),

--- a/tests/unit/sync/syncEngine.deletion.test.ts
+++ b/tests/unit/sync/syncEngine.deletion.test.ts
@@ -173,6 +173,7 @@ describe('SyncEngine deletion permutations', () => {
 		removeOwnWrite: Mock;
 		isOwnWrite: Mock;
 		markInitialSyncDone: Mock;
+		addDirtyFile: Mock;
 	};
 
 	const createEngine = (shouldSyncPath: (path: string) => boolean = () => true) =>
@@ -228,6 +229,7 @@ describe('SyncEngine deletion permutations', () => {
 			removeOwnWrite: vi.fn(),
 			isOwnWrite: vi.fn().mockReturnValue(false),
 			markInitialSyncDone: vi.fn(),
+			addDirtyFile: vi.fn(),
 		};
 	});
 
@@ -965,6 +967,52 @@ describe('SyncEngine deletion permutations', () => {
 				expect(stateManager.getFileState('B.md')).toMatchObject({ oneDriveId: 'id-x' });
 			});
 		}
+
+		// The old path's tracked state must survive a failed MOVE, or the
+		// retry falls into the "no tracked state for old path" branch and
+		// strands a copy on OneDrive under the old name.
+		it('keeps the old path tracked when an atomic move fails', async () => {
+			const localFile = makeTFile('notes/b.md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('notes/a.md', 'stable-id', 'old-hash');
+			mockEventManager.getDirtyFiles.mockReturnValue([
+				{ path: 'notes/b.md', oldPath: 'notes/a.md', type: LocalChangeType.RENAME },
+			]);
+			mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: 'delta-link-next' });
+			mockFileOps.moveFile.mockRejectedValue(new Error('network blip'));
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+				path === 'notes/b.md' ? localFile : null
+			);
+
+			await createEngine().performSync();
+
+			expect(mockFileOps.moveFile).toHaveBeenCalled();
+			expect(stateManager.getFileState('notes/a.md')).toMatchObject({
+				oneDriveId: 'stable-id',
+			});
+		});
+
+		it('retires the old path only once the atomic move succeeds', async () => {
+			const localFile = makeTFile('notes/b.md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('notes/a.md', 'stable-id', 'old-hash');
+			mockEventManager.getDirtyFiles.mockReturnValue([
+				{ path: 'notes/b.md', oldPath: 'notes/a.md', type: LocalChangeType.RENAME },
+			]);
+			mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: 'delta-link-next' });
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+				path === 'notes/b.md' ? localFile : null
+			);
+
+			await createEngine().performSync();
+
+			expect(stateManager.getFileState('notes/a.md')).toBeUndefined();
+			expect(stateManager.getFileState('notes/b.md')).toMatchObject({
+				oneDriveId: 'stable-id',
+			});
+		});
 
 		// A delta batch captured before a move this device already applied
 		// would otherwise rename the file backwards.

--- a/tests/unit/sync/syncEngine.deletion.test.ts
+++ b/tests/unit/sync/syncEngine.deletion.test.ts
@@ -869,6 +869,138 @@ describe('SyncEngine deletion permutations', () => {
 			expect(mockFileOps.downloadFile).not.toHaveBeenCalled();
 		});
 
+		// A CREATE_DUPLICATE conflict copy is downloaded with the BASE file's
+		// oneDriveId, so two tracked paths share one id. The move detector must
+		// not read that alias as "the base file moved to the conflict copy".
+		it('does not trash a conflict copy that shares the base file oneDriveId', async () => {
+			const base = makeTFile('n.md', 100, 1);
+			const copy = makeTFile('n (conflict).md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('n.md', 'shared-id', 'n.md-hash');
+			// Written second, so the reverse index resolves shared-id → copy
+			trackFile('n (conflict).md', 'shared-id', 'n.md-hash');
+			mockClient.getDelta.mockResolvedValue({
+				items: [makeRemoteFile('n.md', { id: 'shared-id' })],
+				deltaLink: 'delta-link-next',
+			});
+			mockApp.vault.adapter.exists.mockResolvedValue(false);
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) => {
+				if (path === 'n.md') return base;
+				if (path === 'n (conflict).md') return copy;
+				return null;
+			});
+
+			await createEngine().performSync();
+
+			expect(mockApp.fileManager.trashFile).not.toHaveBeenCalled();
+			expect(mockApp.vault.rename).not.toHaveBeenCalled();
+		});
+
+		// adapter.exists is case-insensitive unless asked otherwise, so a
+		// case-only rename must not be mistaken for "destination occupied".
+		it('renames in place for a case-only rename instead of trashing and re-downloading', async () => {
+			const localFile = makeTFile('Test.md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('Test.md', 'stable-id', 'test.md-hash');
+			mockClient.getDelta.mockResolvedValue({
+				items: [makeRemoteFile('test.md', { id: 'stable-id' })],
+				deltaLink: 'delta-link-next',
+			});
+			// Case-insensitive filesystem: 'test.md' reports as existing
+			mockApp.vault.adapter.exists.mockImplementation((path: string, sensitive?: boolean) =>
+				Promise.resolve(!sensitive && path.toLowerCase() === 'test.md')
+			);
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+				path === 'Test.md' ? localFile : null
+			);
+
+			await createEngine().performSync();
+
+			expect(mockApp.fileManager.trashFile).not.toHaveBeenCalled();
+			expect(mockApp.vault.rename).toHaveBeenCalledWith(localFile, 'test.md');
+			expect(mockFileOps.downloadFile).not.toHaveBeenCalled();
+		});
+
+		// Obsidian refuses to rename onto an existing name, so "delete B, then
+		// rename A → B" is a common pattern. Both delta orderings must end with
+		// B holding A's content — never with both files gone.
+		for (const order of ['move-first', 'delete-first'] as const) {
+			it(`keeps A's content at B for delete-then-rename in one batch (${order})`, async () => {
+				const fileA = makeTFile('A.md', 100, 1);
+				const fileB = makeTFile('B.md', 100, 1);
+				stateManager.setLastSyncTime(Date.now());
+				stateManager.setDeltaLink('prev-delta');
+				trackFile('A.md', 'id-x', 'B.md-hash');
+				trackFile('B.md', 'id-y', 'B-old-hash');
+				const moved = makeRemoteFile('B.md', { id: 'id-x' });
+				const removed = makeRemoteDelete('B.md', { id: 'id-y' });
+				mockClient.getDelta.mockResolvedValue({
+					items: order === 'move-first' ? [moved, removed] : [removed, moved],
+					deltaLink: 'delta-link-next',
+				});
+				mockApp.vault.adapter.exists.mockResolvedValue(false);
+				const present = new Map<string, TFile>([
+					['A.md', fileA],
+					['B.md', fileB],
+				]);
+				mockApp.fileManager.trashFile.mockImplementation(async (f: { path: string }) => {
+					present.delete(f.path);
+				});
+				mockApp.vault.rename.mockImplementation(async (f: TFile, dest: string) => {
+					present.delete(f.path);
+					present.set(dest, f);
+				});
+				mockApp.vault.getAbstractFileByPath.mockImplementation(
+					(path: string) => present.get(path) ?? null
+				);
+
+				await createEngine().performSync();
+
+				// B.md must survive holding X's content (by rename or download),
+				// A.md must be gone, and B.md must be tracked as X.
+				expect(present.has('B.md')).toBe(true);
+				expect(present.has('A.md')).toBe(false);
+				expect(stateManager.getFileState('B.md')).toMatchObject({ oneDriveId: 'id-x' });
+			});
+		}
+
+		// A delta batch captured before a move this device already applied
+		// would otherwise rename the file backwards.
+		it('ignores a delta item older than the tracked state', async () => {
+			const localFile = makeTFile('notes/b.md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			stateManager.setFileState('notes/b.md', {
+				path: 'notes/b.md',
+				localMtime: 1,
+				remoteHash: 'notes/a.md-hash',
+				size: 100,
+				remoteModifiedTime: 5000,
+				oneDriveId: 'stable-id',
+			});
+			mockClient.getDelta.mockResolvedValue({
+				items: [
+					makeRemoteFile('notes/a.md', {
+						id: 'stable-id',
+						lastModifiedDateTime: new Date(1000).toISOString(),
+					}),
+				],
+				deltaLink: 'delta-link-next',
+			});
+			mockApp.vault.adapter.exists.mockResolvedValue(false);
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+				path === 'notes/b.md' ? localFile : null
+			);
+
+			await createEngine().performSync();
+
+			expect(mockApp.vault.rename).not.toHaveBeenCalled();
+			expect(mockApp.fileManager.trashFile).not.toHaveBeenCalled();
+			expect(stateManager.getFileState('notes/b.md')).toMatchObject({ oneDriveId: 'stable-id' });
+		});
+
 		it('leaves the file alone when the same path has a pending local change', async () => {
 			const localFile = makeTFile('notes/a.md', 100, 1);
 			stateManager.setLastSyncTime(Date.now());
@@ -899,7 +1031,12 @@ describe('SyncEngine deletion permutations', () => {
 			mockEventManager.getDirtyFiles.mockReturnValue([
 				{ path: 'notes/b.md', oldPath: 'notes/a.md', type: LocalChangeType.RENAME },
 			]);
-			mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: 'delta-link-next' });
+			// Delta still echoes the pre-move item at the OLD path with the same
+			// id (issue #138) — this must not be read as a remote move.
+			mockClient.getDelta.mockResolvedValue({
+				items: [makeRemoteFile('notes/a.md', { id: 'stable-id' })],
+				deltaLink: 'delta-link-next',
+			});
 			mockApp.vault.adapter.exists.mockResolvedValue(false);
 			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
 				path === 'notes/b.md' ? localFile : null
@@ -908,6 +1045,7 @@ describe('SyncEngine deletion permutations', () => {
 			await createEngine().performSync();
 
 			expect(mockApp.vault.rename).not.toHaveBeenCalled();
+			expect(mockApp.fileManager.trashFile).not.toHaveBeenCalled();
 			expect(mockFileOps.moveFile).toHaveBeenCalledWith('stable-id', '/remote/root/notes/b.md');
 		});
 	});

--- a/tests/unit/sync/syncEngine.deletion.test.ts
+++ b/tests/unit/sync/syncEngine.deletion.test.ts
@@ -163,7 +163,7 @@ function buildFolderTree(folderPaths: string[], filePaths: string[]) {
 describe('SyncEngine deletion permutations', () => {
 	let stateManager: SyncStateManager;
 	let conflictResolver: ConflictResolver;
-	let mockFileOps: { uploadFile: Mock; downloadFile: Mock; deleteFile: Mock };
+	let mockFileOps: { uploadFile: Mock; downloadFile: Mock; deleteFile: Mock; moveFile: Mock };
 	let mockClient: { getDelta: Mock; listAllItems: Mock; isSharedDrive: Mock };
 	let mockEventManager: {
 		getDirtyFiles: Mock;
@@ -211,6 +211,9 @@ describe('SyncEngine deletion permutations', () => {
 			uploadFile: vi.fn().mockResolvedValue(makeRemoteFile('uploaded.md', { id: 'uploaded-id' })),
 			downloadFile: vi.fn().mockResolvedValue(new ArrayBuffer(10)),
 			deleteFile: vi.fn().mockResolvedValue(undefined),
+			moveFile: vi
+				.fn()
+				.mockImplementation((id: string) => Promise.resolve(makeRemoteFile('moved.md', { id }))),
 		};
 		mockClient = {
 			getDelta: vi.fn().mockResolvedValue({ items: [], deltaLink: 'delta-link-next' }),
@@ -724,6 +727,188 @@ describe('SyncEngine deletion permutations', () => {
 		expect(stateManager.getFileState('notes/old-folder/child.md')).toBeUndefined();
 		expect(stateManager.getFileState('notes/new-folder/child.md')).toMatchObject({
 			oneDriveId: 'child-file-id',
+		});
+	});
+
+	// Regression tests for issue #50: a file renamed on one device (atomic
+	// PATCH move — the OneDrive id survives, so delta reports the item only
+	// at its new path with no delete for the old one) left every other device
+	// holding both the old and the new name.
+	describe('remote file moves (issue #50)', () => {
+		const trackFile = (path: string, id: string, hash: string) => {
+			stateManager.setFileState(path, {
+				path,
+				localMtime: 1,
+				remoteHash: hash,
+				size: 100,
+				remoteModifiedTime: 2,
+				oneDriveId: id,
+			});
+		};
+
+		it('renames the local file instead of leaving a duplicate behind', async () => {
+			const localFile = makeTFile('Test Sync.md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('Test Sync.md', 'stable-id', 'Test Sync 111.md-hash');
+			mockClient.getDelta.mockResolvedValue({
+				items: [makeRemoteFile('Test Sync 111.md', { id: 'stable-id' })],
+				deltaLink: 'delta-link-next',
+			});
+			mockApp.vault.adapter.exists.mockResolvedValue(false);
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+				path === 'Test Sync.md' ? localFile : null
+			);
+
+			await createEngine().performSync();
+
+			expect(mockApp.vault.rename).toHaveBeenCalledWith(localFile, 'Test Sync 111.md');
+			expect(mockEventManager.markOwnWrites).toHaveBeenCalledWith([
+				'Test Sync.md',
+				'Test Sync 111.md',
+			]);
+			expect(stateManager.getFileState('Test Sync.md')).toBeUndefined();
+			expect(stateManager.getFileState('Test Sync 111.md')).toMatchObject({
+				oneDriveId: 'stable-id',
+			});
+			// Pure rename — the tracked hash moved with the state, so there is
+			// nothing left to download.
+			expect(mockFileOps.downloadFile).not.toHaveBeenCalled();
+		});
+
+		it('still downloads the new path when the remote move also changed content', async () => {
+			const localFile = makeTFile('notes/a.md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('notes/a.md', 'stable-id', 'stale-hash');
+			mockClient.getDelta.mockResolvedValue({
+				items: [makeRemoteFile('notes/b.md', { id: 'stable-id' })],
+				deltaLink: 'delta-link-next',
+			});
+			mockApp.vault.adapter.exists.mockResolvedValue(false);
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+				path === 'notes/a.md' ? localFile : null
+			);
+
+			await createEngine().performSync();
+
+			expect(mockApp.vault.rename).toHaveBeenCalledWith(localFile, 'notes/b.md');
+			expect(mockFileOps.downloadFile).toHaveBeenCalledWith('stable-id');
+		});
+
+		it('trashes the stale old copy when the new path already exists locally', async () => {
+			const oldFile = makeTFile('notes/a.md', 100, 1);
+			const newFile = makeTFile('notes/b.md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('notes/a.md', 'stable-id', 'notes/b.md-hash');
+			mockClient.getDelta.mockResolvedValue({
+				items: [makeRemoteFile('notes/b.md', { id: 'stable-id' })],
+				deltaLink: 'delta-link-next',
+			});
+			mockApp.vault.adapter.exists.mockResolvedValue(false);
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) => {
+				if (path === 'notes/a.md') return oldFile;
+				if (path === 'notes/b.md') return newFile;
+				return null;
+			});
+
+			await createEngine().performSync();
+
+			expect(mockApp.vault.rename).not.toHaveBeenCalled();
+			expect(mockApp.fileManager.trashFile).toHaveBeenCalledWith(oldFile);
+			expect(stateManager.getFileState('notes/a.md')).toBeUndefined();
+		});
+
+		it('drops stale tracking and downloads when the old path was never present locally', async () => {
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('notes/a.md', 'stable-id', 'notes/b.md-hash');
+			mockClient.getDelta.mockResolvedValue({
+				items: [makeRemoteFile('notes/b.md', { id: 'stable-id' })],
+				deltaLink: 'delta-link-next',
+			});
+			mockApp.vault.adapter.exists.mockResolvedValue(false);
+			mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+
+			await createEngine().performSync();
+
+			expect(mockApp.vault.rename).not.toHaveBeenCalled();
+			expect(stateManager.getFileState('notes/a.md')).toBeUndefined();
+			expect(mockFileOps.downloadFile).toHaveBeenCalledWith('stable-id');
+			expect(stateManager.getFileState('notes/b.md')).toMatchObject({
+				oneDriveId: 'stable-id',
+			});
+		});
+
+		it('moves a config file via the adapter, since it is not in the vault index', async () => {
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('.obsidian/snippets/a.css', 'stable-id', '.obsidian/snippets/b.css-hash');
+			mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: 'delta-link-next' });
+			mockClient.getDelta.mockResolvedValueOnce({ items: [], deltaLink: 'delta-link-next' });
+			mockClient.getDelta.mockResolvedValueOnce({
+				items: [makeRemoteFile('.obsidian/snippets/b.css', { id: 'stable-id' })],
+				deltaLink: 'obsidian-delta-next',
+			});
+			mockApp.vault.adapter.exists.mockImplementation((path: string) =>
+				Promise.resolve(path === '.obsidian/snippets/a.css')
+			);
+			mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+
+			await createEngine().performSync();
+
+			expect(mockApp.vault.adapter.rename).toHaveBeenCalledWith(
+				'.obsidian/snippets/a.css',
+				'.obsidian/snippets/b.css'
+			);
+			expect(stateManager.getFileState('.obsidian/snippets/a.css')).toBeUndefined();
+			expect(stateManager.getFileState('.obsidian/snippets/b.css')).toMatchObject({
+				oneDriveId: 'stable-id',
+			});
+			expect(mockFileOps.downloadFile).not.toHaveBeenCalled();
+		});
+
+		it('leaves the file alone when the same path has a pending local change', async () => {
+			const localFile = makeTFile('notes/a.md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('notes/a.md', 'stable-id', 'old-hash');
+			mockEventManager.getDirtyFiles.mockReturnValue([
+				{ path: 'notes/a.md', type: LocalChangeType.MODIFY },
+			]);
+			mockClient.getDelta.mockResolvedValue({
+				items: [makeRemoteFile('notes/b.md', { id: 'stable-id' })],
+				deltaLink: 'delta-link-next',
+			});
+			mockApp.vault.adapter.exists.mockResolvedValue(false);
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+				path === 'notes/a.md' ? localFile : null
+			);
+
+			await createEngine().performSync();
+
+			expect(mockApp.vault.rename).not.toHaveBeenCalled();
+		});
+
+		it('does not treat a locally-initiated atomic move as a remote move', async () => {
+			const localFile = makeTFile('notes/b.md', 100, 1);
+			stateManager.setLastSyncTime(Date.now());
+			stateManager.setDeltaLink('prev-delta');
+			trackFile('notes/a.md', 'stable-id', 'old-hash');
+			mockEventManager.getDirtyFiles.mockReturnValue([
+				{ path: 'notes/b.md', oldPath: 'notes/a.md', type: LocalChangeType.RENAME },
+			]);
+			mockClient.getDelta.mockResolvedValue({ items: [], deltaLink: 'delta-link-next' });
+			mockApp.vault.adapter.exists.mockResolvedValue(false);
+			mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) =>
+				path === 'notes/b.md' ? localFile : null
+			);
+
+			await createEngine().performSync();
+
+			expect(mockApp.vault.rename).not.toHaveBeenCalled();
+			expect(mockFileOps.moveFile).toHaveBeenCalledWith('stable-id', '/remote/root/notes/b.md');
 		});
 	});
 


### PR DESCRIPTION
Tentative fix for #50 — opened as a **draft** because the diagnosis is inferred from code plus reported symptoms, not yet confirmed by a debug log from an affected device. See the "How to confirm" section below.

## Diagnosis

An atomic move is `PATCH /items/{id}` with a new `name` + `parentReference` (`src/api/oneDriveClient.ts:467`). The item **keeps its id**, so Graph delta reports the rename as a single changed item at its **new** path — there is no `deleted` entry for the old path.

On the receiving device, the remote pass in `planOperations` keys tracked-state lookups by **path only**. It sees an untracked path, plans a download, and nothing ever removes the old local file. Both paths stay tracked.

The stale copy is not marked dirty, so it does not re-upload on its own — it sits there until a later local action touches it (in the report, renaming one of the two copies), at which point it propagates to OneDrive and on to every other client. That matches the reported escalation to 2/2/3/4 copies.

Folder moves already had an equivalent fix (`applyRemoteFolderMoves`, #163). Files never did.

### Why it isn't a failed delete

If Graph *had* sent a delete for the old path, it would carry the old item's id — which the receiving device tracks, since the file was correctly synced on both devices beforehand. That reverse-resolution path works and is covered by an existing passing test (`syncEngine.deletion.test.ts:429`). The old file would have been removed. It wasn't, so no delete arrived.

## Fix

A pre-planning pass in `src/sync/syncEngine.ts`:

- `detectRemoteFileMoves` — resolves each non-deleted delta item's id via `stateManager.getPathByOneDriveId`; a tracked path differing from the delta's path *is* a remote move.
- `applyRemoteFileMoves` — renames the local file in place (`vault.rename`, or `adapter.rename` for `.obsidian/` files) and carries the tracked state over. Because the hash moves with the state, a pure rename costs **zero downloads**.

Runs after `applyRemoteFolderMoves` so files already relocated by a parent folder move aren't double-counted.

Edge cases handled:
- pending local change or queued conflict on either path → skip, let the planner own it
- destination already exists locally → trash the old copy instead of renaming onto it (this also repairs vaults that already have duplicates)
- old path never existed locally → drop stale tracking so the new path downloads normally

## Verification

Reproduced the symptom against **unmodified 2.0.1 source** in a separate worktree. Feeding the reported repro's delta (one item, new path, same id):

```
downloadFile calls: [["stable-id"]]
writeBinary paths: ["Test Sync 111.md"]
trashFile calls:   0
tracked paths:     ["Test Sync.md", "Test Sync 111.md"]   <- both
old file still present locally: true
```

7 regression tests added. The 5 substantive ones fail pre-fix and pass post-fix; the 2 guard tests (pending local change, locally-initiated move) pass on both, so they aren't vacuous. Full suite 543 passing — the single `logManager.test.ts` failure is a pre-existing date-boundary flake, confirmed by stashing and re-running.

## Adversarial review — three data-loss defects found and fixed

A second pass found that the first commit, while fixing the reported bug, introduced worse behaviour in three cases. Each now has a regression test that fails against the first commit:

1. **Conflict copies were trashed.** `CREATE_DUPLICATE` downloads the dated copy with the *base* file's `oneDriveId`, so two tracked paths share one id and the reverse index resolves to whichever was written last. The next delta echo read as "conflict copy moved to base path" and the copy was trashed. Now skipped when the delta's own path already tracks that id.

2. **Case-only renames were trashed and re-downloaded.** `adapter.exists` is case-insensitive unless asked otherwise, so `Test.md` → `test.md` looked like an occupied destination. Now short-circuits, and passes `sensitive: true` elsewhere.

3. **"Delete B, then rename A → B" in one batch could lose both files.** Obsidian refuses to rename onto an existing name, so this shape is common. With the move ahead of the delete in the batch, A was trashed as a duplicate and B was then deleted by the planner — leaving nothing, strictly worse than pre-fix, which at least kept A. The destination is now cleared first when the same batch deletes it, and that delete entry is dropped so the planner doesn't remove what was just moved in.

Also added: a guard against an older-than-tracked-state delta renaming a file backwards; `remoteModifiedTime` refreshed on a move (never the hash, which is what tells the planner a content change still needs downloading); and an adapter-rename fallback when `vault.rename` fails, so a move into a freshly created folder degrades to working rather than to a duplicate.

The "locally-initiated move" test used an empty delta and never exercised the #138 echo it was named for — it now includes the echo.

## Known-unaddressed (pre-existing, not introduced here)

- **Shared-id delete hazard.** Because conflict copies and existing duplicates can share one `oneDriveId`, a local delete of the *copy* resolves to that id and deletes the **real** file on OneDrive and everywhere else. This is a plausible explanation for the escalating copy counts in #50 and is worth its own issue; a one-time sanitization (ids tracked under more than one path) would close it.
- Users who already have duplicates get no relief until that item is reported by delta again, or they run **Reconcile from cloud**.
- Concurrent renames of the same file on two devices still produce a duplicate (correctly skipped here, not resolved).
- A remote move *out of* sync scope is filtered before this pass, so the local file survives untracked.
- `planOperations` drops the old path's state at plan time, before the MOVE executes, so a failed MOVE leaves the file untracked — the likely source of the separate `no tracked state for old path` warning. Worth a follow-up.

## How to confirm (why this is still a draft)

There are no debug logs anywhere on #50. The decisive datum is whether the receiving device's delta contains a DELETE for the old path — `src/sync/syncEngine.ts:812` already logs exactly that per item.

This diagnosis predicts the receiving-side log shows a `Remote: CHANGED <new path>` line, **no** `Remote: DELETE` line, and `deletes=0` on the summary line. If a DELETE line is present, the diagnosis is wrong and the bug lives in delete resolution instead.

Not for merge until that's confirmed, or until a maintainer is satisfied by the code argument alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WMbGr54C7oowEBqd8z7pH

